### PR TITLE
Use inferred schema instead of table schema 

### DIFF
--- a/src/test.ml
+++ b/src/test.ml
@@ -186,6 +186,14 @@ let test_manual_param = [
   ];
 ]
 
+let test_left_join = [
+  tt "CREATE TABLE account_types ( type_id INT NOT NULL PRIMARY KEY, type_name VARCHAR(255) NOT NULL )" [] [];
+  tt "CREATE TABLE users (id INT NOT NULL, user_id INT NOT NULL PRIMARY KEY, name VARCHAR(255), email VARCHAR(255), account_type_id INT NULL, FOREIGN KEY (account_type_id) REFERENCES account_types(type_id))" [][];
+  tt "SELECT users.name, users.email, account_types.type_name FROM users LEFT JOIN account_types ON users.account_type_id = account_types.type_id"
+  [attr "name" Text ~extra:[]; attr "email" Text ~extra:[]; 
+  {name="type_name"; domain=Type.nullable Text; extra=(Constraints.of_list [Constraint.NotNull]);}] [];
+]
+
 
 let run () =
   Gen.params_mode := Some Named;
@@ -199,6 +207,7 @@ let run () =
     "JOIN result columns" >:: test_join_result_cols;
     "enum" >::: test_enum;
     "manual_param" >::: test_manual_param;
+    "test_left_join" >::: test_left_join;
   ]
   in
   let test_suite = "main" >::: tests in

--- a/test/left_join.sql
+++ b/test/left_join.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS account_types ( 
+    type_id INT NOT NULL PRIMARY KEY, 
+    type_name VARCHAR(255) NOT NULL 
+);
+CREATE TABLE IF NOT EXISTS users (
+    id INT NOT NULL, 
+    user_id INT NOT NULL PRIMARY KEY, 
+    name VARCHAR(255), 
+    email VARCHAR(255), 
+    account_type_id INT NULL, 
+    FOREIGN KEY (account_type_id) 
+    REFERENCES account_types(type_id)
+);
+
+SELECT 
+    users.name,
+    users.email, 
+    account_types.type_name FROM users 
+LEFT JOIN account_types ON users.account_type_id = account_types.type_id;

--- a/test/out/left_join.xml
+++ b/test/out/left_join.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_account_types" sql="CREATE TABLE IF NOT EXISTS account_types ( &#x0A;    type_id INT NOT NULL PRIMARY KEY, &#x0A;    type_name VARCHAR(255) NOT NULL &#x0A;)" category="DDL" kind="create" target="account_types" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_users" sql="CREATE TABLE IF NOT EXISTS users (&#x0A;    id INT NOT NULL, &#x0A;    user_id INT NOT NULL PRIMARY KEY, &#x0A;    name VARCHAR(255), &#x0A;    email VARCHAR(255), &#x0A;    account_type_id INT NULL, &#x0A;    FOREIGN KEY (account_type_id) &#x0A;    REFERENCES account_types(type_id)&#x0A;)" category="DDL" kind="create" target="users" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_2" sql="SELECT &#x0A;    users.name,&#x0A;    users.email, &#x0A;    account_types.type_name FROM users &#x0A;LEFT JOIN account_types ON users.account_type_id = account_types.type_id" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="name" type="Text"/>
+   <value name="email" type="Text"/>
+   <value name="type_name" type="Text" nullable="true"/>
+  </out>
+ </stmt>
+ <table name="users">
+  <schema>
+   <value name="id" type="Int"/>
+   <value name="user_id" type="Int"/>
+   <value name="name" type="Text"/>
+   <value name="email" type="Text"/>
+   <value name="account_type_id" type="Int" nullable="true"/>
+  </schema>
+ </table>
+ <table name="account_types">
+  <schema>
+   <value name="type_id" type="Int"/>
+   <value name="type_name" type="Text"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/out/multidel.xml
+++ b/test/out/multidel.xml
@@ -68,8 +68,8 @@
  </stmt>
  <stmt name="delete_foo_not_alias" sql="DELETE foo&#x0A;FROM foo as f LEFT JOIN bar as b ON f.id = b.foo_id&#x0A;WHERE bar.baz = @bad OR b.baz = @bad2" category="DML" kind="delete" target="foo" cardinality="0">
   <in>
-   <value name="bad" type="Text"/>
-   <value name="bad2" type="Text"/>
+   <value name="bad" type="Text" nullable="true"/>
+   <value name="bad2" type="Text" nullable="true"/>
   </in>
   <out/>
  </stmt>

--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -130,8 +130,8 @@
    <value name="id" type="Int"/>
    <value name="started_at" type="Datetime" nullable="true"/>
    <value name="finished_at" type="Datetime" nullable="true"/>
-   <value name="started_at_should_be_nullable" type="Datetime"/>
-   <value name="finished_at_should_be_nullable" type="Datetime"/>
+   <value name="started_at_should_be_nullable" type="Datetime" nullable="true"/>
+   <value name="finished_at_should_be_nullable" type="Datetime" nullable="true"/>
   </out>
  </stmt>
  <table name="tests">

--- a/test/out/subquery.xml
+++ b/test/out/subquery.xml
@@ -13,7 +13,7 @@
   <in/>
   <out>
    <value name="m_id" type="Int"/>
-   <value name="d_id" type="Int"/>
+   <value name="d_id" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT x.* FROM (&#x0A;  SELECT 1, 'foo', NULL&#x0A;) x" category="DQL" kind="select" cardinality="n">


### PR DESCRIPTION
### Description

This pull request addresses an issue in join operations where column types displayed for requested columns are overridden by types from the tables, leading to inaccuracies. Specifically, in scenarios like a LEFT JOIN, the right side may incorrectly lose nullability information and become non-nullable.