### PR TITLE
Use inferred schema instead of table schema

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -154,7 +154,7 @@ type attr = {name : string; domain : Type.t; extra : Constraints.t; }
 
 let make_attribute name kind extra =
   if Constraints.mem Null extra && Constraints.mem NotNull extra then fail "Column %s can be either NULL or NOT NULL, but not both" name;
-  let domain = Type.{ t = Option.default Int kind; nullability = if Constraints.mem Null extra then Nullable else Strict } in
+  let domain = Type.{ t = Option.default Int kind; nullability = if  not @@ Constraints.mem NotNull extra then Nullable else Strict } in
   {name;domain;extra}
 
 let unnamed_attribute domain = {name="";domain;extra=Constraints.empty}

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -154,7 +154,7 @@ type attr = {name : string; domain : Type.t; extra : Constraints.t; }
 
 let make_attribute name kind extra =
   if Constraints.mem Null extra && Constraints.mem NotNull extra then fail "Column %s can be either NULL or NOT NULL, but not both" name;
-  let domain = Type.{ t = Option.default Int kind; nullability = if  not @@ Constraints.mem NotNull extra then Nullable else Strict } in
+  let domain = Type.{ t = Option.default Int kind; nullability = if Constraints.mem NotNull extra then Strict else Nullable } in
   {name;domain;extra}
 
 let unnamed_attribute domain = {name="";domain;extra=Constraints.empty}

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -339,7 +339,7 @@ reference_action_clause:
 
 reference_action:
   RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT { }
-
+  
 on_conflict: ON CONFLICT algo=conflict_algo { algo }
 column_def_extra: PRIMARY? KEY { Some PrimaryKey }
                 | NOT NULL { Some NotNull }
@@ -348,7 +348,7 @@ column_def_extra: PRIMARY? KEY { Some PrimaryKey }
                 | AUTOINCREMENT { Some Autoincrement }
                 | on_conflict { None }
                 | CHECK LPAREN expr RPAREN { None }
-                | DEFAULT e=default_value { match e with Value { t = Any; nullability = _ } -> Some Null | _ -> None } (* FIXME check type with column *)
+                | DEFAULT default_value { None }
                 | COLLATE IDENT { None }
                 | pair(GENERATED,ALWAYS)? AS LPAREN expr RPAREN either(VIRTUAL,STORED)? { None } (* FIXME params and typing ignored *)
 

--- a/src/test.ml
+++ b/src/test.ml
@@ -186,6 +186,14 @@ let test_manual_param = [
   ];
 ]
 
+let test_left_join = [
+  tt "CREATE TABLE account_types ( type_id INT NOT NULL PRIMARY KEY, type_name VARCHAR(255) NOT NULL )" [] [];
+  tt "CREATE TABLE users (id INT NOT NULL, user_id INT NOT NULL PRIMARY KEY, name VARCHAR(255), email VARCHAR(255), account_type_id INT NULL, FOREIGN KEY (account_type_id) REFERENCES account_types(type_id))" [][];
+  tt "SELECT users.name, users.email, account_types.type_name FROM users LEFT JOIN account_types ON users.account_type_id = account_types.type_id"
+  [attr "name" Text ~extra:[]; attr "email" Text ~extra:[]; 
+  {name="type_name"; domain=Type.nullable Text; extra=(Constraints.of_list [Constraint.NotNull]);}] [];
+]
+
 
 let run () =
   Gen.params_mode := Some Named;
@@ -199,6 +207,7 @@ let run () =
     "JOIN result columns" >:: test_join_result_cols;
     "enum" >::: test_enum;
     "manual_param" >::: test_manual_param;
+    "test_left_join" >::: test_left_join;
   ]
   in
   let test_suite = "main" >::: tests in

--- a/test/left_join.sql
+++ b/test/left_join.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS account_types ( 
+    type_id INT NOT NULL PRIMARY KEY, 
+    type_name VARCHAR(255) NOT NULL 
+);
+CREATE TABLE IF NOT EXISTS users (
+    id INT NOT NULL, 
+    user_id INT NOT NULL PRIMARY KEY, 
+    name VARCHAR(255), 
+    email VARCHAR(255), 
+    account_type_id INT NULL, 
+    FOREIGN KEY (account_type_id) 
+    REFERENCES account_types(type_id)
+);
+
+SELECT 
+    users.name,
+    users.email, 
+    account_types.type_name FROM users 
+LEFT JOIN account_types ON users.account_type_id = account_types.type_id;

--- a/test/out/bug39_select_if.xml
+++ b/test/out/bug39_select_if.xml
@@ -10,16 +10,16 @@
    <value name="x" type="Datetime"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
-   <value name="host" type="Text"/>
-   <value name="_2" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="host" type="Text" nullable="true"/>
+   <value name="_2" type="Int" nullable="true"/>
   </out>
  </stmt>
  <table name="profiles">
   <schema>
-   <value name="id" type="Int"/>
-   <value name="host" type="Text"/>
-   <value name="today_count" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="host" type="Text" nullable="true"/>
+   <value name="today_count" type="Int" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/bug7.xml
+++ b/test/out/bug7.xml
@@ -8,21 +8,21 @@
  <stmt name="ins1" sql="insert into test1 values (@x1,@x2)" category="DML" kind="insert" target="test1" cardinality="0">
   <in>
    <value name="x1" type="Int"/>
-   <value name="x2" type="Int"/>
+   <value name="x2" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="ins2" sql="insert into test1 (x1,x2) values (@x1,@x2)" category="DML" kind="insert" target="test1" cardinality="0">
   <in>
    <value name="x1" type="Int"/>
-   <value name="x2" type="Int"/>
+   <value name="x2" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <table name="test1">
   <schema>
    <value name="x1" type="Int"/>
-   <value name="x2" type="Int"/>
+   <value name="x2" type="Int" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/database.xml
+++ b/test/out/database.xml
@@ -17,14 +17,14 @@
  </stmt>
  <table name="database2.test">
   <schema>
-   <value name="id" type="Int"/>
-   <value name="amount" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="amount" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="database1.test">
   <schema>
-   <value name="id" type="Int"/>
-   <value name="txt" type="Text"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="txt" type="Text" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/float.xml
+++ b/test/out/float.xml
@@ -8,13 +8,13 @@
  <stmt name="insert" sql="insert into transactions values (@amount,@date)" category="DML" kind="insert" target="transactions" cardinality="0">
   <in>
    <value name="amount" type="Float"/>
-   <value name="date" type="Datetime"/>
+   <value name="date" type="Datetime" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="select" sql="select amount + 2.5 from transactions where `date` &gt; @date and amount &gt; @limit" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="date" type="Datetime"/>
+   <value name="date" type="Datetime" nullable="true"/>
    <value name="limit" type="Float"/>
   </in>
   <out>
@@ -24,7 +24,7 @@
  <table name="transactions">
   <schema>
    <value name="amount" type="Float"/>
-   <value name="date" type="Datetime"/>
+   <value name="date" type="Datetime" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/inargument.xml
+++ b/test/out/inargument.xml
@@ -11,29 +11,29 @@
  </stmt>
  <stmt name="find" sql="SELECT * FROM foo&#x0A;WHERE id IN @@ids" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="ids" type="set(Int)"/>
+   <value name="ids" type="set(Int)" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="get" sql="SELECT * FROM foo&#x0A;WHERE (id IN @@ids)&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="ids" type="set(Int)"/>
+   <value name="ids" type="set(Int)" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="find2" sql="SELECT * FROM foo&#x0A;WHERE (id IN @@ids) AND foo NOT IN @@foos" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="ids" type="set(Int)"/>
+   <value name="ids" type="set(Int)" nullable="true"/>
    <value name="foos" type="set(Text)" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -43,17 +43,17 @@
    <value name="foos_with_suffix" type="set(Text)"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="get2" sql="SELECT * FROM foo&#x0A;WHERE id IN @@ids AND (foo NOT IN @@foos)&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="ids" type="set(Int)"/>
+   <value name="ids" type="set(Int)" nullable="true"/>
    <value name="foos" type="set(Text)" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -64,7 +64,7 @@
    <value name="lengths" type="set(Int)"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
    <value name="foo_id" type="Int"/>
    <value name="baz" type="Text"/>
@@ -78,7 +78,7 @@
  </table>
  <table name="foo">
   <schema>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </schema>
  </table>

--- a/test/out/interval.xml
+++ b/test/out/interval.xml
@@ -8,168 +8,168 @@
  <stmt name="select_1" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_2" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MINUTE &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_4" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_5" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_6" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` WEEK &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_7" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MONTH &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_8" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` QUARTER &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_9" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` YEAR &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_10" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` SECOND_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_11" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MINUTE_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_12" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MINUTE_SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_13" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_14" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR_SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_15" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR_MINUTE &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_16" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_17" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_18" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_MINUTE &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_19" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_HOUR &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_20" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` YEAR_MONTH &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <table name="events">
   <schema>
-   <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime"/>
-   <value name="interval" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="interval" type="Int" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/left_join.xml
+++ b/test/out/left_join.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_account_types" sql="CREATE TABLE IF NOT EXISTS account_types ( &#x0A;    type_id INT NOT NULL PRIMARY KEY, &#x0A;    type_name VARCHAR(255) NOT NULL &#x0A;)" category="DDL" kind="create" target="account_types" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_users" sql="CREATE TABLE IF NOT EXISTS users (&#x0A;    id INT NOT NULL, &#x0A;    user_id INT NOT NULL PRIMARY KEY, &#x0A;    name VARCHAR(255), &#x0A;    email VARCHAR(255), &#x0A;    account_type_id INT NULL, &#x0A;    FOREIGN KEY (account_type_id) &#x0A;    REFERENCES account_types(type_id)&#x0A;)" category="DDL" kind="create" target="users" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_2" sql="SELECT &#x0A;    users.name,&#x0A;    users.email, &#x0A;    account_types.type_name FROM users &#x0A;LEFT JOIN account_types ON users.account_type_id = account_types.type_id" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="name" type="Text"/>
+   <value name="email" type="Text"/>
+   <value name="type_name" type="Text" nullable="true"/>
+  </out>
+ </stmt>
+ <table name="users">
+  <schema>
+   <value name="id" type="Int"/>
+   <value name="user_id" type="Int"/>
+   <value name="name" type="Text"/>
+   <value name="email" type="Text"/>
+   <value name="account_type_id" type="Int" nullable="true"/>
+  </schema>
+ </table>
+ <table name="account_types">
+  <schema>
+   <value name="type_id" type="Int"/>
+   <value name="type_name" type="Text"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/out/left_join.xml
+++ b/test/out/left_join.xml
@@ -12,8 +12,8 @@
  <stmt name="select_2" sql="SELECT &#x0A;    users.name,&#x0A;    users.email, &#x0A;    account_types.type_name FROM users &#x0A;LEFT JOIN account_types ON users.account_type_id = account_types.type_id" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="name" type="Text"/>
-   <value name="email" type="Text"/>
+   <value name="name" type="Text" nullable="true"/>
+   <value name="email" type="Text" nullable="true"/>
    <value name="type_name" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -21,8 +21,8 @@
   <schema>
    <value name="id" type="Int"/>
    <value name="user_id" type="Int"/>
-   <value name="name" type="Text"/>
-   <value name="email" type="Text"/>
+   <value name="name" type="Text" nullable="true"/>
+   <value name="email" type="Text" nullable="true"/>
    <value name="account_type_id" type="Int" nullable="true"/>
   </schema>
  </table>

--- a/test/out/misc.xml
+++ b/test/out/misc.xml
@@ -14,8 +14,8 @@
  <stmt name="select_2" sql="SELECT * FROM test WHERE x IS NOT NULL" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="x" type="Int"/>
-   <value name="key" type="Text"/>
+   <value name="x" type="Int" nullable="true"/>
+   <value name="key" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="create_index_key" sql="CREATE INDEX `key` ON test(`key`(20))" category="DDL" kind="create_index" target="key" cardinality="0">
@@ -36,18 +36,18 @@
  </stmt>
  <stmt name="select_6" sql="SELECT x FROM test WHERE @_0 &gt;= `key` ORDER BY `key` DESC LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Text" nullable="true"/>
   </in>
   <out>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_7" sql="SELECT x FROM test WHERE `key` &lt; @_0" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Text" nullable="true"/>
   </in>
   <out>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="create_appointments" sql="CREATE TABLE appointments (alert_at DATETIME)" category="DDL" kind="create" target="appointments" cardinality="0">
@@ -72,31 +72,31 @@
  </stmt>
  <stmt name="insert_issue14_12" sql="INSERT INTO issue14 (x) VALUES (@x)" category="DML" kind="insert" target="issue14" cardinality="0">
   <in>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_issue14_13" sql="INSERT INTO issue14 SET x = @x" category="DML" kind="insert" target="issue14" cardinality="0">
   <in>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_issue14_14" sql="INSERT INTO issue14 (x) SELECT @x" category="DML" kind="insert" target="issue14" cardinality="0">
   <in>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_test_15" sql="INSERT INTO test VALUES (20, 'twenty') ON DUPLICATE KEY UPDATE x = x + @_0" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="_0" type="Int"/>
+   <value name="_0" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_test_16" sql="INSERT INTO test VALUES (20, 'twenty') ON DUPLICATE KEY UPDATE x = VALUES(x) + @_0" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="_0" type="Int"/>
+   <value name="_0" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
@@ -136,14 +136,14 @@
  </stmt>
  <stmt name="issue45" sql="INSERT INTO test VALUES&#x0A;(1, @one),&#x0A;(2, @two),&#x0A;(3, @one)" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="two" type="Text"/>
-   <value name="one" type="Text"/>
+   <value name="two" type="Text" nullable="true"/>
+   <value name="one" type="Text" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_appointments_25" sql="INSERT INTO `appointments` ( `alert_at`) VALUES (@alert)" category="DML" kind="insert" target="appointments" cardinality="0">
   <in>
-   <value name="alert" type="Datetime"/>
+   <value name="alert" type="Datetime" nullable="true"/>
   </in>
   <out/>
  </stmt>
@@ -163,7 +163,7 @@
   <in/>
   <out>
    <value name="_0" type="Int"/>
-   <value name="_1" type="Int"/>
+   <value name="_1" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="issue54_mysql" sql="SELECT 0 &lt;=&gt; 0, 0 &lt;=&gt; null, null &lt;=&gt; 0, null &lt;=&gt; null" category="DQL" kind="select" cardinality="1">
@@ -197,8 +197,8 @@
  </stmt>
  <stmt name="delete_test_33" sql="delete from test&#x0A;where x in (@x1, @x2)&#x0A;  and not exists (select 1 from workareas where work_id = test.x)" category="DML" kind="delete" target="test" cardinality="0">
   <in>
-   <value name="x1" type="Int"/>
-   <value name="x2" type="Int"/>
+   <value name="x1" type="Int" nullable="true"/>
+   <value name="x2" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
@@ -209,14 +209,14 @@
  <stmt name="issue63" sql="select * from issue63 where x like 'hello%' or y like 'world%'" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="x" type="Text"/>
-   <value name="y" type="Text"/>
+   <value name="x" type="Text" nullable="true"/>
+   <value name="y" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="last_insert_id" sql="INSERT INTO `workareas` (`about`,`k`) VALUES (NULLIF(@about, ''),@k)&#x0A;ON DUPLICATE KEY UPDATE&#x0A;  `work_id` = LAST_INSERT_ID(`work_id`)" category="DML" kind="insert" target="workareas" cardinality="0">
   <in>
    <value name="about" type="Text"/>
-   <value name="k" type="Int"/>
+   <value name="k" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
@@ -239,20 +239,20 @@
  <stmt name="group_by_having" sql="select x, count(*) nr from test group by x having nr &gt; 1" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
    <value name="nr" type="Int"/>
   </out>
  </stmt>
  <stmt name="select_alias" sql="select x &lt;&gt; 0 AS y from test" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="y" type="Bool"/>
+   <value name="y" type="Bool" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_alias_change_type" sql="select x &lt;&gt; 0 AS x from test" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="x" type="Bool"/>
+   <value name="x" type="Bool" nullable="true"/>
   </out>
  </stmt>
  <stmt name="create_oauth_tokens" sql="CREATE TABLE IF NOT EXISTS `oauth_tokens` (&#x0A;  `id` INTEGER UNSIGNED PRIMARY KEY AUTO_INCREMENT,&#x0A;  `unique_value_google_drive` BINARY(16) AS (&#x0A;  CASE WHEN `client_name` = &quot;google-drive&quot; THEN&#x0A;    UNHEX(MD5(CONCAT_WS(&quot;|&quot;, `creator_user_id`, `email`)))&#x0A;  ELSE&#x0A;    NULL&#x0A;  END) UNIQUE&#x0A;)" category="DDL" kind="create" target="oauth_tokens" cardinality="0">
@@ -261,43 +261,43 @@
  </stmt>
  <table name="oauth_tokens">
   <schema>
-   <value name="id" type="Int"/>
-   <value name="unique_value_google_drive" type="Text"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="unique_value_google_drive" type="Text" nullable="true"/>
   </schema>
  </table>
  <table name="adr">
   <schema>
    <value name="word" type="Text"/>
-   <value name="amount" type="Int"/>
+   <value name="amount" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="issue63">
   <schema>
-   <value name="x" type="Text"/>
-   <value name="y" type="Text"/>
+   <value name="x" type="Text" nullable="true"/>
+   <value name="y" type="Text" nullable="true"/>
   </schema>
  </table>
  <table name="workareas">
   <schema>
-   <value name="work_id" type="Int"/>
-   <value name="about" type="Text"/>
-   <value name="k" type="Int"/>
+   <value name="work_id" type="Int" nullable="true"/>
+   <value name="about" type="Text" nullable="true"/>
+   <value name="k" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="issue14">
   <schema>
-   <value name="x" type="Int"/>
+   <value name="x" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="appointments">
   <schema>
-   <value name="alert_at" type="Datetime"/>
+   <value name="alert_at" type="Datetime" nullable="true"/>
   </schema>
  </table>
  <table name="test">
   <schema>
-   <value name="x" type="Int"/>
-   <value name="key" type="Text"/>
+   <value name="x" type="Int" nullable="true"/>
+   <value name="key" type="Text" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/money.xml
+++ b/test/out/money.xml
@@ -7,8 +7,8 @@
  </stmt>
  <stmt name="add_person" sql="INSERT INTO person (name,surname) VALUES (@name,@surname)" category="DML" kind="insert" target="person" cardinality="0">
   <in>
-   <value name="name" type="Text"/>
-   <value name="surname" type="Text"/>
+   <value name="name" type="Text" nullable="true"/>
+   <value name="surname" type="Text" nullable="true"/>
   </in>
   <out/>
  </stmt>
@@ -18,9 +18,9 @@
  </stmt>
  <stmt name="add_money" sql="INSERT INTO money VALUES (@src,@dst,@amount)" category="DML" kind="insert" target="money" cardinality="0">
   <in>
-   <value name="src" type="Int"/>
-   <value name="dst" type="Int"/>
-   <value name="amount" type="Int"/>
+   <value name="src" type="Int" nullable="true"/>
+   <value name="dst" type="Int" nullable="true"/>
+   <value name="amount" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
@@ -28,7 +28,7 @@
   <in/>
   <out>
    <value name="fullname" type="Text"/>
-   <value name="total" type="Int"/>
+   <value name="total" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="list_donors" sql="SELECT DISTINCT surname FROM person JOIN money ON src = id AND dst = (SELECT id FROM person WHERE surname LIKE @_0) LIMIT @limit" category="DQL" kind="select" cardinality="n">
@@ -37,7 +37,7 @@
    <value name="limit" type="Int"/>
   </in>
   <out>
-   <value name="surname" type="Text"/>
+   <value name="surname" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="drop_person" sql="DROP TABLE IF EXISTS person" category="DDL" kind="drop" target="person" cardinality="0">

--- a/test/out/multidel.xml
+++ b/test/out/multidel.xml
@@ -14,7 +14,7 @@
    <value name="foo" type="Text" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -81,7 +81,7 @@
  </table>
  <table name="foo">
   <schema>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="foo" type="Text" nullable="true"/>
   </schema>
  </table>

--- a/test/out/multidel.xml
+++ b/test/out/multidel.xml
@@ -68,8 +68,8 @@
  </stmt>
  <stmt name="delete_foo_not_alias" sql="DELETE foo&#x0A;FROM foo as f LEFT JOIN bar as b ON f.id = b.foo_id&#x0A;WHERE bar.baz = @bad OR b.baz = @bad2" category="DML" kind="delete" target="foo" cardinality="0">
   <in>
-   <value name="bad" type="Text"/>
-   <value name="bad2" type="Text"/>
+   <value name="bad" type="Text" nullable="true"/>
+   <value name="bad2" type="Text" nullable="true"/>
   </in>
   <out/>
  </stmt>

--- a/test/out/nested_join.xml
+++ b/test/out/nested_join.xml
@@ -28,7 +28,7 @@
  <stmt name="select_6" sql="SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a2 LEFT JOIN t3 ON t2.b2 = t3.b OR t2.b2 IS NULL" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="a" type="Int"/>
+   <value name="a" type="Int" nullable="true"/>
    <value name="a2" type="Int" nullable="true"/>
    <value name="b2" type="Int" nullable="true"/>
    <value name="b" type="Int" nullable="true"/>
@@ -37,7 +37,7 @@
  <stmt name="select_7" sql="SELECT * FROM t1 LEFT JOIN (t2 LEFT JOIN t3 ON t2.b2 = t3.b OR t2.b2 IS NULL) ON t1.a = t2.a2" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="a" type="Int"/>
+   <value name="a" type="Int" nullable="true"/>
    <value name="a2" type="Int" nullable="true"/>
    <value name="b2" type="Int" nullable="true"/>
    <value name="b" type="Int" nullable="true"/>
@@ -46,7 +46,7 @@
  <stmt name="select_8" sql="SELECT * FROM (t1 LEFT JOIN t2 ON t1.a = t2.a2) LEFT JOIN t3 ON t2.b2 = t3.b OR t2.b2 IS NULL" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="a" type="Int"/>
+   <value name="a" type="Int" nullable="true"/>
    <value name="a2" type="Int" nullable="true"/>
    <value name="b2" type="Int" nullable="true"/>
    <value name="b" type="Int" nullable="true"/>
@@ -54,18 +54,18 @@
  </stmt>
  <table name="t3">
   <schema>
-   <value name="b" type="Int"/>
+   <value name="b" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="t2">
   <schema>
-   <value name="a2" type="Int"/>
-   <value name="b2" type="Int"/>
+   <value name="a2" type="Int" nullable="true"/>
+   <value name="b2" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="t1">
   <schema>
-   <value name="a" type="Int"/>
+   <value name="a" type="Int" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -130,8 +130,8 @@
    <value name="id" type="Int"/>
    <value name="started_at" type="Datetime" nullable="true"/>
    <value name="finished_at" type="Datetime" nullable="true"/>
-   <value name="started_at_should_be_nullable" type="Datetime"/>
-   <value name="finished_at_should_be_nullable" type="Datetime"/>
+   <value name="started_at_should_be_nullable" type="Datetime" nullable="true"/>
+   <value name="finished_at_should_be_nullable" type="Datetime" nullable="true"/>
   </out>
  </stmt>
  <table name="tests">

--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -20,7 +20,7 @@
  <stmt name="list" sql="SELECT `id`, IFNULL(`nullable`, 0) `nullable` FROM `test`" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="nullable" type="Int"/>
   </out>
  </stmt>
@@ -42,7 +42,7 @@
  <stmt name="list_nullable" sql="SELECT `id`, `nullable` FROM test" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="nullable" type="Datetime" nullable="true"/>
   </out>
  </stmt>
@@ -79,7 +79,7 @@
  <stmt name="select_plus" sql="SELECT id + IFNULL(nullable_int, 0) FROM test" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="_0" type="Int"/>
+   <value name="_0" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_plus_null" sql="SELECT id + NULL FROM test" category="DQL" kind="select" cardinality="n">
@@ -103,11 +103,11 @@
  </stmt>
  <stmt name="get_max" sql="SELECT&#x0A;  max(nullable),&#x0A;  max(id),&#x0A;  IF(max(nullable) IS NULL, now(), max(nullable)),&#x0A;  IF(max(nullable) IS NULL, NULL, max(nullable))&#x0A;FROM&#x0A;  test&#x0A;WHERE&#x0A;  id = @id&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="1">
   <in>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
   </in>
   <out>
    <value name="_0" type="Datetime" nullable="true"/>
-   <value name="_1" type="Int"/>
+   <value name="_1" type="Int" nullable="true"/>
    <value name="_2" type="Datetime" nullable="true"/>
    <value name="_3" type="Datetime" nullable="true"/>
   </out>
@@ -127,7 +127,7 @@
    <value name="x" type="Int" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="started_at" type="Datetime" nullable="true"/>
    <value name="finished_at" type="Datetime" nullable="true"/>
    <value name="started_at_should_be_nullable" type="Datetime" nullable="true"/>
@@ -136,15 +136,15 @@
  </stmt>
  <table name="tests">
   <schema>
-   <value name="test_id" type="Int"/>
-   <value name="run_id" type="Int"/>
+   <value name="test_id" type="Int" nullable="true"/>
+   <value name="run_id" type="Int" nullable="true"/>
    <value name="started_at" type="Datetime"/>
    <value name="finished_at" type="Datetime"/>
   </schema>
  </table>
  <table name="test">
   <schema>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="nullable" type="Datetime" nullable="true"/>
    <value name="nullable_too" type="Datetime" nullable="true"/>
    <value name="nullable_int" type="Int" nullable="true"/>

--- a/test/out/subquery.xml
+++ b/test/out/subquery.xml
@@ -13,7 +13,7 @@
   <in/>
   <out>
    <value name="m_id" type="Int"/>
-   <value name="d_id" type="Int"/>
+   <value name="d_id" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT x.* FROM (&#x0A;  SELECT 1, 'foo', NULL&#x0A;) x" category="DQL" kind="select" cardinality="n">

--- a/test/out/subquery.xml
+++ b/test/out/subquery.xml
@@ -12,7 +12,7 @@
  <stmt name="select_2" sql="SELECT m.`id` m_id, d.`id` d_id&#x0A;FROM `master` m&#x0A;LEFT JOIN `detail` d ON d.`id` = (&#x0A;  SELECT dd.`id`&#x0A;  FROM `detail` dd&#x0A;  WHERE dd.`master_id` = m.`id`&#x0A;  ORDER BY dd.`id` DESC&#x0A;  LIMIT 1&#x0A;)" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="m_id" type="Int"/>
+   <value name="m_id" type="Int" nullable="true"/>
    <value name="d_id" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -40,7 +40,7 @@
  <stmt name="select_6" sql="SELECT id, NULL FROM master&#x0A;UNION SELECT id, NOW() FROM master" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
    <value name="_1" type="Datetime" nullable="true"/>
   </out>
  </stmt>
@@ -50,14 +50,14 @@
  </stmt>
  <table name="detail">
   <schema>
-   <value name="id" type="Int"/>
-   <value name="master_id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
+   <value name="master_id" type="Int" nullable="true"/>
    <value name="at" type="Datetime" nullable="true"/>
   </schema>
  </table>
  <table name="master">
   <schema>
-   <value name="id" type="Int"/>
+   <value name="id" type="Int" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/types.xml
+++ b/test/out/types.xml
@@ -19,22 +19,22 @@
  </stmt>
  <stmt name="insert_foo_3" sql="INSERT INTO foo ( x ) VALUES (@x)" category="DML" kind="insert" target="foo" cardinality="0">
   <in>
-   <value name="x" type="Decimal"/>
+   <value name="x" type="Decimal" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="select_4" sql="SELECT x FROM foo" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="x" type="Decimal"/>
+   <value name="x" type="Decimal" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_5" sql="SELECT SUM(x) FROM foo WHERE x &lt; @n" category="DQL" kind="select" cardinality="1">
   <in>
-   <value name="n" type="Decimal"/>
+   <value name="n" type="Decimal" nullable="true"/>
   </in>
   <out>
-   <value name="_0" type="Decimal"/>
+   <value name="_0" type="Decimal" nullable="true"/>
   </out>
  </stmt>
  <stmt name="insert_foo_6" sql="insert into foo ( x ) values ( cast(1.2 as decimal) ), ( 100 )" category="DML" kind="insert" target="foo" cardinality="0">
@@ -43,7 +43,7 @@
  </stmt>
  <table name="foo">
   <schema>
-   <value name="x" type="Decimal"/>
+   <value name="x" type="Decimal" nullable="true"/>
   </schema>
  </table>
  <table name="%%tablename%%">

--- a/test/out/uuid.xml
+++ b/test/out/uuid.xml
@@ -8,12 +8,12 @@
  <stmt name="select_1" sql="SELECT * FROM XXX" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Text"/>
+   <value name="id" type="Text" nullable="true"/>
   </out>
  </stmt>
  <table name="xxx">
   <schema>
-   <value name="id" type="Text"/>
+   <value name="id" type="Text" nullable="true"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/window.xml
+++ b/test/out/window.xml
@@ -11,40 +11,40 @@
  </stmt>
  <stmt name="select_2" sql="SELECT pk, LAG(pk) OVER (ORDER BY pk) AS l,&#x0A;  LAG(pk,1) OVER (ORDER BY pk) AS l1,&#x0A;  LAG(pk+@inc,2) OVER (ORDER BY pk) AS l2,&#x0A;  LAG(pk,0) OVER (ORDER BY pk) AS l0,&#x0A;  LAG(pk,-1) OVER (ORDER BY pk) AS lm1,&#x0A;  LAG(pk,-2) OVER (ORDER BY pk) AS lm2 &#x0A;FROM t1" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="inc" type="Int"/>
+   <value name="inc" type="Int" nullable="true"/>
   </in>
   <out>
-   <value name="pk" type="Int"/>
-   <value name="l" type="Int"/>
-   <value name="l1" type="Int"/>
-   <value name="l2" type="Int"/>
-   <value name="l0" type="Int"/>
-   <value name="lm1" type="Int"/>
-   <value name="lm2" type="Int"/>
+   <value name="pk" type="Int" nullable="true"/>
+   <value name="l" type="Int" nullable="true"/>
+   <value name="l1" type="Int" nullable="true"/>
+   <value name="l2" type="Int" nullable="true"/>
+   <value name="l0" type="Int" nullable="true"/>
+   <value name="lm1" type="Int" nullable="true"/>
+   <value name="lm2" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT pk, LEAD(pk) OVER (ORDER BY pk) AS l,&#x0A;  LEAD(pk,1) OVER (ORDER BY pk) AS l1,&#x0A;  LEAD(pk+@inc,2) OVER (ORDER BY pk) AS l2,&#x0A;  LEAD(pk,0) OVER (ORDER BY pk) AS l0,&#x0A;  LEAD(pk,-1) OVER (ORDER BY pk) AS lm1,&#x0A;  LEAD(pk,-2) OVER (ORDER BY pk) AS lm2 &#x0A;FROM t1" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="inc" type="Int"/>
+   <value name="inc" type="Int" nullable="true"/>
   </in>
   <out>
-   <value name="pk" type="Int"/>
-   <value name="l" type="Int"/>
-   <value name="l1" type="Int"/>
-   <value name="l2" type="Int"/>
-   <value name="l0" type="Int"/>
-   <value name="lm1" type="Int"/>
-   <value name="lm2" type="Int"/>
+   <value name="pk" type="Int" nullable="true"/>
+   <value name="l" type="Int" nullable="true"/>
+   <value name="l1" type="Int" nullable="true"/>
+   <value name="l2" type="Int" nullable="true"/>
+   <value name="l0" type="Int" nullable="true"/>
+   <value name="lm1" type="Int" nullable="true"/>
+   <value name="lm2" type="Int" nullable="true"/>
   </out>
  </stmt>
  <table name="t1">
   <schema>
-   <value name="pk" type="Int"/>
-   <value name="a" type="Int"/>
-   <value name="b" type="Int"/>
-   <value name="c" type="Text"/>
-   <value name="d" type="Float"/>
-   <value name="e" type="Float"/>
+   <value name="pk" type="Int" nullable="true"/>
+   <value name="a" type="Int" nullable="true"/>
+   <value name="b" type="Int" nullable="true"/>
+   <value name="c" type="Text" nullable="true"/>
+   <value name="d" type="Float" nullable="true"/>
+   <value name="e" type="Float" nullable="true"/>
   </schema>
  </table>
 </sqlgg>


### PR DESCRIPTION
### Description

This pull request addresses an issue in join operations where column types displayed for requested columns are overridden by types from the tables, leading to inaccuracies. Specifically, in scenarios like a LEFT JOIN, the right side may incorrectly lose nullability information and become non-nullable.