### PR TITLE
Improve Coalesce Function for Proper Type Inference

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -110,6 +110,7 @@ struct
   | Group of t (* _ -> t *)
   | Agg (* 'a -> 'a *)
   | Multi of tyvar * tyvar (* 'a -> ... -> 'a -> 'b *)
+  | Coalesce of tyvar * tyvar
   | Ret of kind (* _ -> t *) (* TODO eliminate *)
   | F of tyvar * tyvar list
 
@@ -125,13 +126,13 @@ struct
   | Group ret -> fprintf pp "|_| -> %s" (show ret)
   | Ret ret -> fprintf pp "_ -> %s" (show_kind ret)
   | F (ret, args) -> fprintf pp "%s -> %s" (String.concat " -> " @@ List.map string_of_tyvar args) (string_of_tyvar ret)
-  | Multi (ret, each_arg) -> fprintf pp "{ %s }+ -> %s" (string_of_tyvar each_arg) (string_of_tyvar ret)
+  | Multi (ret, each_arg) | Coalesce (ret, each_arg) -> fprintf pp "{ %s }+ -> %s" (string_of_tyvar each_arg) (string_of_tyvar ret)
 
   let string_of_func = Format.asprintf "%a" pp_func
 
   let is_grouping = function
   | Group _ | Agg -> true
-  | Ret _ | F _ | Multi _ -> false
+  | Ret _ | F _ | Multi _ | Coalesce _ -> false
 end
 
 module Constraint =
@@ -456,6 +457,7 @@ val exclude : int -> string -> unit
 val monomorphic : Type.t -> Type.t list -> string -> unit
 val multi : ret:Type.tyvar -> Type.tyvar -> string -> unit
 val multi_polymorphic : string -> unit
+val add_multi: Type.func -> string -> unit
 val sponge : Type.func
 
 end = struct
@@ -517,7 +519,7 @@ let () =
   "floor" |> monomorphic int [float];
   "nullif" |> add 2 (F (Var 0 (* TODO nullable *), [Var 0; Var 0]));
   "ifnull" |> add 2 (F (Var 0, [Var 1; Var 0]));
-  ["least";"greatest";"coalesce"] ||> multi_polymorphic;
+  ["least";"greatest";] ||> multi_polymorphic;
   "strftime" |> exclude 1; (* requires at least 2 arguments *)
   ["concat";"concat_ws";"strftime"] ||> multi ~ret:(Typ text) (Typ text);
   "date" |> monomorphic datetime [datetime];
@@ -535,4 +537,5 @@ let () =
   "substring_index" |> monomorphic text [text; text; int];
   "last_insert_id" |> monomorphic int [];
   "last_insert_id" |> monomorphic int [int];
+  add_multi Type.(Coalesce (Var 0, Var 0)) "coalesce";
   ()

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -202,9 +202,10 @@ and assign_types expr =
             (String.concat ", " @@ List.map show types)
         in
         if !debug then eprintfn "func %s" (show_func ());
+        let types_to_arg each_arg = List.map (Fun.const each_arg) types in
         let func =
           match func with
-          | Multi (ret,each_arg) -> F (ret, List.map (fun _ -> each_arg) types)
+          | Multi (ret,each_arg) -> F (ret, types_to_arg each_arg)
           | x -> x
         in
         let convert_args ret args = 
@@ -240,16 +241,15 @@ and assign_types expr =
         | Agg, _ -> fail "cannot use this grouping function with %d parameters" (List.length types)
         | F (_, args), _ when List.length args <> List.length types -> fail "wrong number of arguments : %s" (show_func ())
         | Coalesce (ret, each_arg) , _ -> 
-          let args = List.map (fun _ -> each_arg) types in
+          let args = types_to_arg each_arg in
           let args, ret = convert_args ret args in
-          let ret = types
-            |> List.find_map_opt (fun arg -> 
-              match arg.nullability with 
-              | Strict -> Some { ret with nullability = Strict }
-              | _ -> None ) 
-            |> Option.default (
-              let nullable = common_nullability args in
-              undepend ret nullable ) in
+          let has_one_strict = List.exists (fun arg ->
+            match arg.nullability with 
+            | Strict -> true | _ -> false
+          ) types in
+          let ret = if has_one_strict then
+            { ret with nullability = Strict }
+            else args |> common_nullability |> undepend ret in 
           ret , args
         | F (ret, args), _ ->
           let args, ret = convert_args ret args in

--- a/src/test.ml
+++ b/src/test.ml
@@ -126,7 +126,7 @@ let test4 =
   tt "select greatest(10,x) from test4" [attr' ~nullability:(Nullable) "" Int] [] ~kind:(Select `Nat);
   tt "select 1+2 from test4 where x=y"  [attr' ~nullability:(Strict) "" Int] [] ~kind:(Select `Nat);
   tt "select max(x) as q from test4 where y = x + @n" [attr' ~nullability:(Nullable) "q" Int] [named_nullable "n" Int] ~kind:(Select `One);
-  tt "select coalesce(max(x),0) as q from test4 where y = x + @n" [attr "q" Int] [named_nullable "n" Int] ~kind:(Select `One); 
+  tt "select coalesce(max(x),0) as q from test4 where y = x + @n" [attr' ~nullability:(Strict) "q" Int] [named_nullable "n" Int] ~kind:(Select `One); 
 ]
 
 let test_parsing = [
@@ -201,6 +201,11 @@ let test_left_join = [
   {name="type_name"; domain=Type.nullable Text; extra=(Constraints.of_list [Constraint.NotNull]);}] [];
 ]
 
+let test_coalesce = [
+  tt "CREATE TABLE test8 (x integer unsigned null)" [] [];
+  tt "SELECT COALESCE(x, null, null) as x FROM test8" [attr' ~nullability:(Nullable) "x" Int;] [];
+  tt "SELECT COALESCE(x, coalesce(null, null, 75, null), null) as x FROM test8" [attr' ~nullability:Strict "x" Int;] [];
+]
 
 let run () =
   Gen.params_mode := Some Named;
@@ -215,6 +220,7 @@ let run () =
     "enum" >::: test_enum;
     "manual_param" >::: test_manual_param;
     "test_left_join" >::: test_left_join;
+    "test_coalesce" >::: test_coalesce;
   ]
   in
   let test_suite = "main" >::: tests in


### PR DESCRIPTION
This pull request enhances the coalesce function to provide accurate type inference. Previously, coalesce didn't behave as expected, but with this update, it correctly outputs a not null type if any of the parameters are not null.