### PR TITLE
Consider primary key as not null

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -155,7 +155,8 @@ type attr = {name : string; domain : Type.t; extra : Constraints.t; }
 
 let make_attribute name kind extra =
   if Constraints.mem Null extra && Constraints.mem NotNull extra then fail "Column %s can be either NULL or NOT NULL, but not both" name;
-  let domain = Type.{ t = Option.default Int kind; nullability = if Constraints.mem NotNull extra then Strict else Nullable } in
+  let domain = Type.{ t = Option.default Int kind; nullability = if List.exists (fun cstrt -> Constraints.mem cstrt extra) [NotNull; PrimaryKey] 
+    then Strict else Nullable } in
   {name;domain;extra}
 
 let unnamed_attribute domain = {name="";domain;extra=Constraints.empty}

--- a/src/test.ml
+++ b/src/test.ml
@@ -207,6 +207,11 @@ let test_coalesce = [
   tt "SELECT COALESCE(x, coalesce(null, null, 75, null), null) as x FROM test8" [attr' ~nullability:Strict "x" Int;] [];
 ]
 
+let test_coalesce = [
+  tt "CREATE TABLE test9 (x BIGINT UNSIGNED PRIMARY KEY)" [] [];
+  tt "SELECT x FROM test9 WHERE x > 100" [attr' ~extra:[PrimaryKey] ~nullability:(Strict) "x" Int;] [];
+]
+
 let run () =
   Gen.params_mode := Some Named;
   let tests =

--- a/test/out/database.xml
+++ b/test/out/database.xml
@@ -17,13 +17,13 @@
  </stmt>
  <table name="database2.test">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="amount" type="Int" nullable="true"/>
   </schema>
  </table>
  <table name="database1.test">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="txt" type="Text" nullable="true"/>
   </schema>
  </table>

--- a/test/out/inargument.xml
+++ b/test/out/inargument.xml
@@ -11,29 +11,29 @@
  </stmt>
  <stmt name="find" sql="SELECT * FROM foo&#x0A;WHERE id IN @@ids" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="ids" type="set(Int)" nullable="true"/>
+   <value name="ids" type="set(Int)"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="get" sql="SELECT * FROM foo&#x0A;WHERE (id IN @@ids)&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="ids" type="set(Int)" nullable="true"/>
+   <value name="ids" type="set(Int)"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="find2" sql="SELECT * FROM foo&#x0A;WHERE (id IN @@ids) AND foo NOT IN @@foos" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="ids" type="set(Int)" nullable="true"/>
+   <value name="ids" type="set(Int)"/>
    <value name="foos" type="set(Text)" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -43,17 +43,17 @@
    <value name="foos_with_suffix" type="set(Text)"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
  <stmt name="get2" sql="SELECT * FROM foo&#x0A;WHERE id IN @@ids AND (foo NOT IN @@foos)&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="ids" type="set(Int)" nullable="true"/>
+   <value name="ids" type="set(Int)"/>
    <value name="foos" type="set(Text)" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -64,7 +64,7 @@
    <value name="lengths" type="set(Int)"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
    <value name="foo_id" type="Int"/>
    <value name="baz" type="Text"/>
@@ -78,7 +78,7 @@
  </table>
  <table name="foo">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </schema>
  </table>

--- a/test/out/interval.xml
+++ b/test/out/interval.xml
@@ -8,7 +8,7 @@
  <stmt name="select_1" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -16,7 +16,7 @@
  <stmt name="select_2" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -24,7 +24,7 @@
  <stmt name="select_3" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MINUTE &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -32,7 +32,7 @@
  <stmt name="select_4" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -40,7 +40,7 @@
  <stmt name="select_5" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -48,7 +48,7 @@
  <stmt name="select_6" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` WEEK &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -56,7 +56,7 @@
  <stmt name="select_7" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MONTH &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -64,7 +64,7 @@
  <stmt name="select_8" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` QUARTER &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -72,7 +72,7 @@
  <stmt name="select_9" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` YEAR &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -80,7 +80,7 @@
  <stmt name="select_10" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` SECOND_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -88,7 +88,7 @@
  <stmt name="select_11" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MINUTE_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -96,7 +96,7 @@
  <stmt name="select_12" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` MINUTE_SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -104,7 +104,7 @@
  <stmt name="select_13" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -112,7 +112,7 @@
  <stmt name="select_14" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR_SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -120,7 +120,7 @@
  <stmt name="select_15" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` HOUR_MINUTE &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -128,7 +128,7 @@
  <stmt name="select_16" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_MICROSECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -136,7 +136,7 @@
  <stmt name="select_17" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_SECOND &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -144,7 +144,7 @@
  <stmt name="select_18" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_MINUTE &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -152,7 +152,7 @@
  <stmt name="select_19" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` DAY_HOUR &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
@@ -160,14 +160,14 @@
  <stmt name="select_20" sql="SELECT * FROM events WHERE stamp + INTERVAL `interval` YEAR_MONTH &lt; NOW()" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
  <table name="events">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="stamp" type="Datetime" nullable="true"/>
    <value name="interval" type="Int" nullable="true"/>
   </schema>

--- a/test/out/misc.xml
+++ b/test/out/misc.xml
@@ -261,7 +261,7 @@
  </stmt>
  <table name="oauth_tokens">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="unique_value_google_drive" type="Text" nullable="true"/>
   </schema>
  </table>

--- a/test/out/multidel.xml
+++ b/test/out/multidel.xml
@@ -14,7 +14,7 @@
    <value name="foo" type="Text" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </out>
  </stmt>
@@ -81,7 +81,7 @@
  </table>
  <table name="foo">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="foo" type="Text" nullable="true"/>
   </schema>
  </table>

--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -20,7 +20,7 @@
  <stmt name="list" sql="SELECT `id`, IFNULL(`nullable`, 0) `nullable` FROM `test`" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="nullable" type="Int"/>
   </out>
  </stmt>
@@ -42,7 +42,7 @@
  <stmt name="list_nullable" sql="SELECT `id`, `nullable` FROM test" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="nullable" type="Datetime" nullable="true"/>
   </out>
  </stmt>
@@ -79,7 +79,7 @@
  <stmt name="select_plus" sql="SELECT id + IFNULL(nullable_int, 0) FROM test" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="_0" type="Int" nullable="true"/>
+   <value name="_0" type="Int"/>
   </out>
  </stmt>
  <stmt name="select_plus_null" sql="SELECT id + NULL FROM test" category="DQL" kind="select" cardinality="n">
@@ -103,11 +103,11 @@
  </stmt>
  <stmt name="get_max" sql="SELECT&#x0A;  max(nullable),&#x0A;  max(id),&#x0A;  IF(max(nullable) IS NULL, now(), max(nullable)),&#x0A;  IF(max(nullable) IS NULL, NULL, max(nullable))&#x0A;FROM&#x0A;  test&#x0A;WHERE&#x0A;  id = @id&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="1">
   <in>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
   </in>
   <out>
    <value name="_0" type="Datetime" nullable="true"/>
-   <value name="_1" type="Int" nullable="true"/>
+   <value name="_1" type="Int"/>
    <value name="_2" type="Datetime" nullable="true"/>
    <value name="_3" type="Datetime" nullable="true"/>
   </out>
@@ -127,7 +127,7 @@
    <value name="x" type="Int" nullable="true"/>
   </in>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="started_at" type="Datetime" nullable="true"/>
    <value name="finished_at" type="Datetime" nullable="true"/>
    <value name="started_at_should_be_nullable" type="Datetime" nullable="true"/>
@@ -144,7 +144,7 @@
  </table>
  <table name="test">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="nullable" type="Datetime" nullable="true"/>
    <value name="nullable_too" type="Datetime" nullable="true"/>
    <value name="nullable_int" type="Int" nullable="true"/>

--- a/test/out/subquery.xml
+++ b/test/out/subquery.xml
@@ -12,7 +12,7 @@
  <stmt name="select_2" sql="SELECT m.`id` m_id, d.`id` d_id&#x0A;FROM `master` m&#x0A;LEFT JOIN `detail` d ON d.`id` = (&#x0A;  SELECT dd.`id`&#x0A;  FROM `detail` dd&#x0A;  WHERE dd.`master_id` = m.`id`&#x0A;  ORDER BY dd.`id` DESC&#x0A;  LIMIT 1&#x0A;)" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="m_id" type="Int" nullable="true"/>
+   <value name="m_id" type="Int"/>
    <value name="d_id" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -40,7 +40,7 @@
  <stmt name="select_6" sql="SELECT id, NULL FROM master&#x0A;UNION SELECT id, NOW() FROM master" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="_1" type="Datetime" nullable="true"/>
   </out>
  </stmt>
@@ -50,14 +50,14 @@
  </stmt>
  <table name="detail">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
    <value name="master_id" type="Int" nullable="true"/>
    <value name="at" type="Datetime" nullable="true"/>
   </schema>
  </table>
  <table name="master">
   <schema>
-   <value name="id" type="Int" nullable="true"/>
+   <value name="id" type="Int"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/uuid.xml
+++ b/test/out/uuid.xml
@@ -8,12 +8,12 @@
  <stmt name="select_1" sql="SELECT * FROM XXX" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="id" type="Text" nullable="true"/>
+   <value name="id" type="Text"/>
   </out>
  </stmt>
  <table name="xxx">
   <schema>
-   <value name="id" type="Text" nullable="true"/>
+   <value name="id" type="Text"/>
   </schema>
  </table>
 </sqlgg>

--- a/test/out/window.xml
+++ b/test/out/window.xml
@@ -11,35 +11,35 @@
  </stmt>
  <stmt name="select_2" sql="SELECT pk, LAG(pk) OVER (ORDER BY pk) AS l,&#x0A;  LAG(pk,1) OVER (ORDER BY pk) AS l1,&#x0A;  LAG(pk+@inc,2) OVER (ORDER BY pk) AS l2,&#x0A;  LAG(pk,0) OVER (ORDER BY pk) AS l0,&#x0A;  LAG(pk,-1) OVER (ORDER BY pk) AS lm1,&#x0A;  LAG(pk,-2) OVER (ORDER BY pk) AS lm2 &#x0A;FROM t1" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="inc" type="Int" nullable="true"/>
+   <value name="inc" type="Int"/>
   </in>
   <out>
-   <value name="pk" type="Int" nullable="true"/>
-   <value name="l" type="Int" nullable="true"/>
-   <value name="l1" type="Int" nullable="true"/>
-   <value name="l2" type="Int" nullable="true"/>
-   <value name="l0" type="Int" nullable="true"/>
-   <value name="lm1" type="Int" nullable="true"/>
-   <value name="lm2" type="Int" nullable="true"/>
+   <value name="pk" type="Int"/>
+   <value name="l" type="Int"/>
+   <value name="l1" type="Int"/>
+   <value name="l2" type="Int"/>
+   <value name="l0" type="Int"/>
+   <value name="lm1" type="Int"/>
+   <value name="lm2" type="Int"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT pk, LEAD(pk) OVER (ORDER BY pk) AS l,&#x0A;  LEAD(pk,1) OVER (ORDER BY pk) AS l1,&#x0A;  LEAD(pk+@inc,2) OVER (ORDER BY pk) AS l2,&#x0A;  LEAD(pk,0) OVER (ORDER BY pk) AS l0,&#x0A;  LEAD(pk,-1) OVER (ORDER BY pk) AS lm1,&#x0A;  LEAD(pk,-2) OVER (ORDER BY pk) AS lm2 &#x0A;FROM t1" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="inc" type="Int" nullable="true"/>
+   <value name="inc" type="Int"/>
   </in>
   <out>
-   <value name="pk" type="Int" nullable="true"/>
-   <value name="l" type="Int" nullable="true"/>
-   <value name="l1" type="Int" nullable="true"/>
-   <value name="l2" type="Int" nullable="true"/>
-   <value name="l0" type="Int" nullable="true"/>
-   <value name="lm1" type="Int" nullable="true"/>
-   <value name="lm2" type="Int" nullable="true"/>
+   <value name="pk" type="Int"/>
+   <value name="l" type="Int"/>
+   <value name="l1" type="Int"/>
+   <value name="l2" type="Int"/>
+   <value name="l0" type="Int"/>
+   <value name="lm1" type="Int"/>
+   <value name="lm2" type="Int"/>
   </out>
  </stmt>
  <table name="t1">
   <schema>
-   <value name="pk" type="Int" nullable="true"/>
+   <value name="pk" type="Int"/>
    <value name="a" type="Int" nullable="true"/>
    <value name="b" type="Int" nullable="true"/>
    <value name="c" type="Text" nullable="true"/>


### PR DESCRIPTION
### Description

PRIMARY KEY
A unique index where all key columns must be defined as NOT NULL. If they are not explicitly declared as NOT NULL, MySQL declares them so implicitly (and silently). A table can have only one PRIMARY KEY. The name of a PRIMARY KEY is always PRIMARY, which thus cannot be used as the name for any other kind of index.

This PR fixes this gap.