### PR TITLE
Add error handling for missing NOT NULL fields without defaults

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -140,7 +140,7 @@ struct
   type conflict_algo = | Ignore | Replace | Abort | Fail | Rollback
     [@@deriving show{with_path=false}, ord]
 
-  type t = | PrimaryKey | NotNull | Null | Unique | Autoincrement | OnConflict of conflict_algo
+  type t = | PrimaryKey | NotNull | Null | Unique | Autoincrement | OnConflict of conflict_algo | WithDefault
     [@@deriving show{with_path=false}, ord]
 end
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -351,9 +351,9 @@ column_def_extra: PRIMARY? KEY { Some PrimaryKey }
                 | NULL { Some Null }
                 | UNIQUE KEY? { Some Unique }
                 | AUTOINCREMENT { Some Autoincrement }
+                | DEFAULT default_value { Some WithDefault }
                 | on_conflict { None }
                 | CHECK LPAREN expr RPAREN { None }
-                | DEFAULT default_value { None }
                 | COLLATE IDENT { None }
                 | pair(GENERATED,ALWAYS)? AS LPAREN expr RPAREN either(VIRTUAL,STORED)? { None } (* FIXME params and typing ignored *)
 

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -36,7 +36,22 @@ let get_or_failwith = function `Error s -> failwith s | `Ok t -> t
 let values_or_all table names =
   let schema = Tables.get_schema table in
   match names with
-  | Some names -> Schema.project names schema
+  | Some names -> 
+    let req_missing =
+      List.filter_map
+        (fun { extra; name; _ } ->
+          let open Constraints in
+          if inter (of_list [Autoincrement; WithDefault; NotNull]) extra = of_list [NotNull]
+            && not @@ List.mem name names then Some name
+          else None
+        )
+        schema
+    in
+    begin match req_missing with 
+    | [] -> ()
+    | fields -> 
+        fail "Fields: (%s) don't have a default value" (String.concat "," fields) end;    
+    Schema.project names schema
   | None -> schema
 
 let rec get_params_of_res_expr (e:res_expr) =

--- a/src/test.ml
+++ b/src/test.ml
@@ -168,16 +168,16 @@ let test_join_result_cols () =
 
 let test_enum = [
   tt "CREATE TABLE test6 (x enum('true','false') COLLATE utf8_bin NOT NULL, y INT DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8" [] [];
-  tt "SELECT * FROM test6" [attr "x" Text ~extra:[NotNull]; attr "y" Int] [];
-  tt "SELECT x, y+10 FROM test6" [attr "x" Text ~extra:[NotNull]; attr "" Int] [];
+  tt "SELECT * FROM test6" [attr "x" Text ~extra:[NotNull;]; attr ~extra:[WithDefault;] "y" Int] [];
+  tt "SELECT x, y+10 FROM test6" [attr "x" Text ~extra:[NotNull;]; attr "" Int] [];
 ]
 
 let test_manual_param = [
   tt "CREATE TABLE test7 (x INT NULL DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8" [] [];
-  tt "SELECT * FROM test7 WHERE x = @x_arg" [attr "x" Int ~extra:[Null];] [
+  tt "SELECT * FROM test7 WHERE x = @x_arg" [attr "x" Int ~extra:[Null; WithDefault];] [
     named_nullable "x_arg" Int
   ];
-  tt "SELECT * FROM test7 WHERE x = @x_arg::Int" [attr "x" Int ~extra:[Null];] [
+  tt "SELECT * FROM test7 WHERE x = @x_arg::Int" [attr "x" Int ~extra:[Null; WithDefault];] [
     named "x_arg" Int
   ];
   tt "INSERT INTO test7 VALUES (@x_arg)" [] [
@@ -212,6 +212,15 @@ let test_coalesce = [
   tt "SELECT x FROM test9 WHERE x > 100" [attr' ~extra:[PrimaryKey] ~nullability:(Strict) "x" Int;] [];
 ]
 
+let test_not_null_default_field = [
+  tt "CREATE TABLE test10 (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL)" [] [];
+  wrong "INSERT INTO test10 (id) VALUES (1)";
+  tt "INSERT INTO test10 (id, name) VALUES (1, '2')" [] [];
+  tt "CREATE TABLE test11 (aa int(10) unsigned NOT NULL DEFAULT 2, b TEXT NOT NULL)" [][];
+  tt "INSERT INTO test11 (b) VALUES ('abcd')" [][];
+
+]
+
 let run () =
   Gen.params_mode := Some Named;
   let tests =
@@ -226,6 +235,7 @@ let run () =
     "manual_param" >::: test_manual_param;
     "test_left_join" >::: test_left_join;
     "test_coalesce" >::: test_coalesce;
+    "test_not_null_default_field" >::: test_not_null_default_field;
   ]
   in
   let test_suite = "main" >::: tests in


### PR DESCRIPTION
This PR updates the code to throw an error during insert operations if NOT NULL fields without default values are missing.
