### PR TITLE
Params inside where expr are NOT NULL by default

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -33,6 +33,8 @@ struct
   let nullable = nullability Nullable
   let make_nullable { t; nullability=_ } = nullable t
 
+  let make_strict { t; nullability=_ } = strict t
+
   let (=) : t -> t -> bool = equal
 
   let show { t; nullability; } = show_kind t ^ (match nullability with Nullable -> "?" | Depends -> "??" | Strict -> "")
@@ -111,6 +113,7 @@ struct
   | Agg (* 'a -> 'a *)
   | Multi of tyvar * tyvar (* 'a -> ... -> 'a -> 'b *)
   | Coalesce of tyvar * tyvar
+  | Comparison
   | Ret of kind (* _ -> t *) (* TODO eliminate *)
   | F of tyvar * tyvar list
 
@@ -127,12 +130,13 @@ struct
   | Ret ret -> fprintf pp "_ -> %s" (show_kind ret)
   | F (ret, args) -> fprintf pp "%s -> %s" (String.concat " -> " @@ List.map string_of_tyvar args) (string_of_tyvar ret)
   | Multi (ret, each_arg) | Coalesce (ret, each_arg) -> fprintf pp "{ %s }+ -> %s" (string_of_tyvar each_arg) (string_of_tyvar ret)
+  | Comparison -> fprintf pp "'a -> 'a -> %s" (show_kind Bool)
 
   let string_of_func = Format.asprintf "%a" pp_func
 
   let is_grouping = function
   | Group _ | Agg -> true
-  | Ret _ | F _ | Multi _ | Coalesce _ -> false
+  | Ret _ | F _ | Multi _ | Coalesce _  | Comparison -> false
 end
 
 module Constraint =

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -380,7 +380,8 @@ expr:
     | e1=expr NUM_DIV_OP e2=expr %prec PLUS { Fun ((Ret Float),[e1;e2]) }
     | e1=expr DIV e2=expr %prec PLUS { Fun ((Ret Int),[e1;e2]) }
     | e1=expr boolean_bin_op e2=expr %prec AND { Fun ((fixed Bool [Bool;Bool]),[e1;e2]) }
-    | e1=expr comparison_op anyall? e2=expr %prec EQUAL { poly (depends Bool) [e1;e2] }
+    | e1=expr comparison_op anyall? e2=expr %prec EQUAL { Fun (Comparison, [e1; e2]) }
+    | e1=expr NOT_DISTINCT_OP anyall? e2=expr %prec EQUAL { poly (depends Bool) [e1;e2]}
     | e1=expr CONCAT_OP e2=expr { Fun ((fixed Text [Text;Text]),[e1;e2]) }
     | e=like_expr esc=escape?
       {
@@ -492,7 +493,7 @@ func_params: DISTINCT? l=expr_list { l }
            | (* *) { [] }
 escape: ESCAPE expr { $2 }
 numeric_bin_op: PLUS | MINUS | ASTERISK | MOD | NUM_BIT_OR | NUM_BIT_AND | NUM_BIT_SHIFT { }
-comparison_op: EQUAL | NUM_CMP_OP | NUM_EQ_OP | NOT_DISTINCT_OP { }
+comparison_op: EQUAL | NUM_CMP_OP | NUM_EQ_OP { }
 boolean_bin_op: AND | OR | XOR { }
 
 unary_op: EXCL { }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -11,6 +11,7 @@ type env = {
   tables : Tables.table list;
   schema : table_name Schema.Source.t;
   insert_schema : Schema.t;
+  param_strict: bool;
 }
 
 (* expr with all name references resolved to values or "functions" *)
@@ -23,7 +24,15 @@ type res_expr =
   | ResFun of Type.func * res_expr list (** function kind (return type and flavor), arguments *)
   [@@deriving show]
 
-let empty_env = { tables = []; schema = []; insert_schema = []; }
+let is_param = function
+  | ResValue _ -> false
+  | ResInparam _ -> false
+  | ResChoices _ -> false
+  | ResInChoice _ -> false
+  | ResFun _ -> false 
+  | ResParam _ -> true
+
+let empty_env = { tables = []; schema = []; insert_schema = []; param_strict = false; }
 
 let flat_map f l = List.flatten (List.map f l)
 
@@ -191,7 +200,7 @@ let rec resolve_columns env expr =
   each expr
 
 (** assign types to parameters where possible *)
-and assign_types expr =
+and assign_types { param_strict; _ } expr =
   let option_split = function None -> None, None | Some (x,y) -> Some x, Some y in
   let rec typeof_ (e:res_expr) = (* FIXME simplify *)
     match e with
@@ -278,6 +287,12 @@ and assign_types expr =
         | Ret ret, _ ->
           let nullability = common_nullability types in
           { t = ret; nullability; }, types (* ignoring arguments FIXME *)
+        | Comparison, _  ->
+          let args, ret = convert_args (Typ (depends Bool)) [Var 0; Var 0] in
+          let nullable = common_nullability args in
+          if param_strict && List.exists is_param params then 
+            make_strict ret, List.map make_strict args 
+          else undepend ret nullable, args
         in
         let assign inferred x =
           match x with
@@ -296,7 +311,7 @@ and assign_types expr =
 and resolve_types env expr =
   let expr = resolve_columns env expr in
   try
-    assign_types expr
+    assign_types env expr
   with
     exn ->
       eprintfn "resolve_types failed with %s at:" (Printexc.to_string exn);
@@ -366,7 +381,8 @@ and params_of_order order final_schema tables =
   List.concat @@
   List.map
     (fun (order, direction) ->
-       let env = { tables; insert_schema = []; schema = final_schema :: tbls |> all_columns } in
+       let env = { tables; insert_schema = []; schema = final_schema :: tbls |> all_columns;
+        param_strict = false } in
        let p1 = get_params_l env [ order ] in
        let p2 =
          match direction with
@@ -412,7 +428,7 @@ and eval_select env { columns; from; where; group; having; } =
   (* use schema without aliases here *)
   let p1 = get_params_of_columns env columns in
   let env = { env with schema = Schema.Join.cross env.schema final_schema |> make_unique } in (* enrich schema in scope with aliases *)
-  let p3 = get_params_opt env where in
+  let p3 = get_params_opt { env with param_strict = true } where in
   let p4 = get_params_l env group in
   let p5 = get_params_opt env having in
   (final_schema, p1 @ p2 @ p3 @ p4 @ p5, env.tables, cardinality)
@@ -461,9 +477,10 @@ let update_tables sources ss w =
   let p0 = List.flatten @@ List.map (fun (_,p,_) -> p) sources in
   let tables = List.flatten @@ List.map (fun (_,_,ts) -> ts) sources in (* TODO assert equal duplicates if not unique *)
   let result = get_columns_schema tables (List.map fst ss) in
-  let env = { tables; schema; insert_schema=List.map (fun i -> i.Schema.Source.Attr.attr) result } in
+  let env = { tables; schema; insert_schema=List.map (fun i -> i.Schema.Source.Attr.attr) result;
+    param_strict = false } in
   let p1 = params_of_assigns env ss in
-  let p2 = get_params_opt env w in
+  let p2 = get_params_opt { env with param_strict = true } w in
   p0 @ p1 @ p2
 
 let annotate_select select types =
@@ -511,7 +528,7 @@ let rec eval (stmt:Sql.stmt) =
     let expect = values_or_all table names in
     let t = Tables.get_schema table in
     let schema = List.map (fun attr -> { sources=[table]; attr }) t in
-    let env = { tables = [Tables.get table]; schema ; insert_schema = expect; } in
+    let env = { empty_env with tables = [Tables.get table]; schema ; insert_schema = expect; } in
     let params, inferred = match values with
     | None -> [], Some (Values, expect)
     | Some values ->
@@ -534,13 +551,13 @@ let rec eval (stmt:Sql.stmt) =
   | Insert { target=table; action=`Param (names, param_id); on_duplicate; } ->
     let expect = values_or_all table names in
     let schema = List.map (fun attr -> { Schema.Source.Attr.sources=[table]; attr }) (Tables.get_schema table) in
-    let env = { tables = [Tables.get table]; schema; insert_schema = expect; } in
+    let env = { empty_env with tables = [Tables.get table]; schema; insert_schema = expect; } in
     let params = [ TupleList (param_id, expect) ] in
     let params2 = params_of_assigns env (Option.default [] on_duplicate) in
     [], params @ params2, Insert (None, table)
   | Insert { target=table; action=`Select (names, select); on_duplicate; } ->
     let expect = values_or_all table names in
-    let env = { tables = [Tables.get table]; 
+    let env = { empty_env with tables = [Tables.get table]; 
       schema = List.map (fun attr -> { sources=[table]; attr }) (Tables.get_schema table); 
       insert_schema = expect;
     } in
@@ -553,7 +570,9 @@ let rec eval (stmt:Sql.stmt) =
     [], params @ params2, Insert (None,table)
   | Insert { target=table; action=`Set ss; on_duplicate; } ->
     let expect = values_or_all table (Option.map (List.map (function ({cname; tname=None},_) -> cname | _ -> assert false)) ss) in
-    let env = { tables = [Tables.get table]; schema = List.map (fun attr -> { sources=[table]; attr }) (Tables.get_schema table); insert_schema = expect;} in
+    let env = { tables = [Tables.get table]; 
+      schema = List.map (fun attr -> { sources=[table]; attr }) (Tables.get_schema table);
+      insert_schema = expect; param_strict = false} in
     let (params,inferred) = match ss with
     | None -> [], Some (Assign, Tables.get_schema table)
     | Some ss -> params_of_assigns env ss, None
@@ -562,7 +581,9 @@ let rec eval (stmt:Sql.stmt) =
     [], params @ params2, Insert (inferred,table)
   | Delete (table, where) ->
     let t = Tables.get table in
-    let p = get_params_opt { tables=[t]; schema=List.map (fun attr -> { Schema.Source.Attr.sources=[t |> fst]; attr }) (t |> snd); insert_schema=[]; } where in
+    let p = get_params_opt { tables=[t]; 
+      schema=List.map (fun attr -> { Schema.Source.Attr.sources=[t |> fst]; attr }) (t |> snd); 
+      insert_schema=[]; param_strict = true } where in
     [], p, Delete [table]
   | DeleteMulti (targets, tables, where) ->
     (* use dummy columns to verify targets match the provided tables  *)

--- a/src/test.ml
+++ b/src/test.ml
@@ -246,12 +246,14 @@ let test_param_not_null_by_default = [
   tt {| 
     SELECT a FROM test15 
     WHERE a = @a 
-    AND a + b = @ab 
+    AND a + b = @ab
+    AND a + @x = 10
     AND c = @c AND a < (@a2 :: Int Null)
-    AND (SELECT d FROM test16 LIMIT 1) = @d 
+    AND (SELECT d FROM test16 LIMIT 1) = @d
   |} [attr "a" Int ~extra:[];] [
     named "a" Int;
     named "ab" Int;
+    named_nullable "x" Int;
     named "c" Text;
     named_nullable "a2" Int;
     named "d" Int;

--- a/test/out/float.xml
+++ b/test/out/float.xml
@@ -14,7 +14,7 @@
  </stmt>
  <stmt name="select" sql="select amount + 2.5 from transactions where `date` &gt; @date and amount &gt; @limit" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="date" type="Datetime" nullable="true"/>
+   <value name="date" type="Datetime"/>
    <value name="limit" type="Float"/>
   </in>
   <out>

--- a/test/out/misc.xml
+++ b/test/out/misc.xml
@@ -36,7 +36,7 @@
  </stmt>
  <stmt name="select_6" sql="SELECT x FROM test WHERE @_0 &gt;= `key` ORDER BY `key` DESC LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="_0" type="Text" nullable="true"/>
+   <value name="_0" type="Text"/>
   </in>
   <out>
    <value name="x" type="Int" nullable="true"/>
@@ -44,7 +44,7 @@
  </stmt>
  <stmt name="select_7" sql="SELECT x FROM test WHERE `key` &lt; @_0" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="_0" type="Text" nullable="true"/>
+   <value name="_0" type="Text"/>
   </in>
   <out>
    <value name="x" type="Int" nullable="true"/>

--- a/test/out/multidel.xml
+++ b/test/out/multidel.xml
@@ -11,7 +11,7 @@
  </stmt>
  <stmt name="find" sql="SELECT * FROM foo WHERE foo = @foo" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="foo" type="Text" nullable="true"/>
+   <value name="foo" type="Text"/>
   </in>
   <out>
    <value name="id" type="Int"/>
@@ -24,52 +24,52 @@
  </stmt>
  <stmt name="delete_foo1" sql="DELETE foo FROM foo WHERE foo = @foo" category="DML" kind="delete" target="foo" cardinality="0">
   <in>
-   <value name="foo" type="Text" nullable="true"/>
+   <value name="foo" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo2" sql="DELETE FROM foo WHERE foo = @foo" category="DML" kind="delete" target="foo" cardinality="0">
   <in>
-   <value name="foo" type="Text" nullable="true"/>
+   <value name="foo" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo3" sql="DELETE foo&#x0A;FROM foo JOIN bar ON foo.id = bar.foo_id&#x0A;WHERE bar.baz = '' OR foo.foo = @badfoo" category="DML" kind="delete" target="foo" cardinality="0">
   <in>
-   <value name="badfoo" type="Text" nullable="true"/>
+   <value name="badfoo" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo_and_bar" sql="DELETE foo, bar&#x0A;FROM foo JOIN bar ON foo.id = bar.foo_id&#x0A;WHERE bar.baz = '' OR foo.foo = @badfoo" category="DML" kind="delete" target="foo,bar" cardinality="0">
   <in>
-   <value name="badfoo" type="Text" nullable="true"/>
+   <value name="badfoo" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo_alias" sql="DELETE f&#x0A;FROM foo f JOIN bar b ON f.id = b.foo_id&#x0A;WHERE b.baz = @badbaz OR f.foo = @badfoo" category="DML" kind="delete" target="f" cardinality="0">
   <in>
    <value name="badbaz" type="Text"/>
-   <value name="badfoo" type="Text" nullable="true"/>
+   <value name="badfoo" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo_and_bar_alias" sql="DELETE f, b&#x0A;FROM foo f JOIN bar b ON f.id = b.foo_id&#x0A;WHERE b.baz = @badbaz OR f.foo = @badfoo" category="DML" kind="delete" target="f,b" cardinality="0">
   <in>
    <value name="badbaz" type="Text"/>
-   <value name="badfoo" type="Text" nullable="true"/>
+   <value name="badfoo" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo_and_bar_alias_rep" sql="DELETE f, b&#x0A;FROM foo f JOIN bar b ON f.id = b.foo_id&#x0A;WHERE b.baz = @bad OR f.foo = @bad" category="DML" kind="delete" target="f,b" cardinality="0">
   <in>
-   <value name="bad" type="Text" nullable="true"/>
+   <value name="bad" type="Text"/>
   </in>
   <out/>
  </stmt>
  <stmt name="delete_foo_not_alias" sql="DELETE foo&#x0A;FROM foo as f LEFT JOIN bar as b ON f.id = b.foo_id&#x0A;WHERE bar.baz = @bad OR b.baz = @bad2" category="DML" kind="delete" target="foo" cardinality="0">
   <in>
-   <value name="bad" type="Text" nullable="true"/>
-   <value name="bad2" type="Text" nullable="true"/>
+   <value name="bad" type="Text"/>
+   <value name="bad2" type="Text"/>
   </in>
   <out/>
  </stmt>

--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -124,7 +124,7 @@
  </stmt>
  <stmt name="select_18" sql="SELECT&#x0A;  test.id,&#x0A;  started_at,&#x0A;  finished_at,&#x0A;  last_test.started_at as started_at_should_be_nullable,&#x0A;  last_test.finished_at as finished_at_should_be_nullable&#x0A;FROM test&#x0A;LEFT JOIN (&#x0A;  SELECT test_id, started_at, finished_at&#x0A;  FROM tests aux&#x0A;  WHERE run_id = (SELECT MAX(run_id) FROM tests WHERE aux.test_id = test_id)&#x0A;) last_test ON last_test.test_id = test.id&#x0A;WHERE&#x0A;  test.nullable_int = @x" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="x" type="Int" nullable="true"/>
+   <value name="x" type="Int"/>
   </in>
   <out>
    <value name="id" type="Int"/>

--- a/test/out/types.xml
+++ b/test/out/types.xml
@@ -31,7 +31,7 @@
  </stmt>
  <stmt name="select_5" sql="SELECT SUM(x) FROM foo WHERE x &lt; @n" category="DQL" kind="select" cardinality="1">
   <in>
-   <value name="n" type="Decimal" nullable="true"/>
+   <value name="n" type="Decimal"/>
   </in>
   <out>
    <value name="_0" type="Decimal" nullable="true"/>


### PR DESCRIPTION
### Description
This PR sets all params inside comparison operators inside where `expr` as non-nullable, besides `<=>`.