### PR TITLE
Support for IN clause with tuple sets

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -353,7 +353,8 @@ and var =
 | SingleIn of param
 | ChoiceIn of { param: param_id; kind : [`In | `NotIn]; vars: var list }
 | Choice of param_id * ctor list
-| TupleList of param_id * schema
+| TupleList of param_id * schema * tuple_list_kind 
+and tuple_list_kind = Insertion | Where_in
 [@@deriving show]
 type vars = var list [@@deriving show]
 
@@ -405,6 +406,7 @@ and expr =
   | SelectExpr of select_full * [ `AsValue | `Exists ]
   | Column of col_name
   | Inserted of string (** inserted value *)
+  | InTupleList of col_name list * param_id
 and column =
   | All
   | AllOf of table_name

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -353,8 +353,8 @@ and var =
 | SingleIn of param
 | ChoiceIn of { param: param_id; kind : [`In | `NotIn]; vars: var list }
 | Choice of param_id * ctor list
-| TupleList of param_id * schema * tuple_list_kind 
-and tuple_list_kind = Insertion | Where_in
+| TupleList of param_id * tuple_list_kind 
+and tuple_list_kind = Insertion of schema | Where_in of Type.t list
 [@@deriving show]
 type vars = var list [@@deriving show]
 
@@ -406,7 +406,7 @@ and expr =
   | SelectExpr of select_full * [ `AsValue | `Exists ]
   | Column of col_name
   | Inserted of string (** inserted value *)
-  | InTupleList of col_name list * param_id
+  | InTupleList of expr list * param_id
 and column =
   | All
   | AllOf of table_name

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -405,6 +405,10 @@ expr:
         let e = poly (depends Bool) [ e1; Inparam (new_param p (depends Any)) ] in
         InChoice ({ label = p.label; pos = ($startofs, $endofs) }, k, e )
       }
+    | LPAREN names=commas(attr_name) RPAREN in_or_not_in p=PARAM
+      {
+        InTupleList(names, p)
+      }      
     | LPAREN select=select_stmt RPAREN { SelectExpr (select, `AsValue) }
     | p=PARAM { Param (new_param p (depends Any)) }
     | p=PARAM DOUBLECOLON t=manual_type { Param (new_param { p with pos=($startofs, $endofs) } t) }

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -405,7 +405,7 @@ expr:
         let e = poly (depends Bool) [ e1; Inparam (new_param p (depends Any)) ] in
         InChoice ({ label = p.label; pos = ($startofs, $endofs) }, k, e )
       }
-    | LPAREN names=commas(attr_name) RPAREN in_or_not_in p=PARAM
+    | LPAREN names=commas(expr) RPAREN in_or_not_in p=PARAM
       {
         InTupleList(names, p)
       }      

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -19,13 +19,15 @@ type env = {
 type res_expr =
   | ResValue of Type.t (** literal value *)
   | ResParam of param
-  | ResInTupleList of param_id * schema
+  | ResInTupleList of param_id * res_in_tuple_list
   | ResInparam of param
   | ResChoices of param_id * res_expr choices
   | ResInChoice of param_id * [`In | `NotIn] * res_expr
   | ResFun of Type.func * res_expr list (** function kind (return type and flavor), arguments *)
   [@@deriving show]
-
+  
+and res_in_tuple_list = 
+  ResTyped of Type.t list | Res of res_expr list
 let empty_env = { tables = []; schema = []; insert_schema = []; set_tyvar_strict = false; }
 
 let flat_map f l = List.flatten (List.map f l)
@@ -61,9 +63,10 @@ let rec get_params_of_res_expr (e:res_expr) =
   let rec loop acc e =
     match e with
     | ResParam p -> Single p::acc
-    | ResInTupleList (param_id, schema) -> TupleList (param_id, schema, Where_in)::acc
+    | ResInTupleList (param_id, ResTyped types) -> TupleList (param_id, Where_in types) :: acc
     | ResInparam p -> SingleIn p::acc
     | ResFun (_,l) -> List.fold_left loop acc l
+    | ResInTupleList _ 
     | ResValue _ -> acc
     | ResInChoice (param, kind, e) -> ChoiceIn { param; kind; vars = get_params_of_res_expr e } :: acc
     | ResChoices (p,l) -> Choice (p, List.map (fun (n,e) -> Simple (n, Option.map get_params_of_res_expr e)) l) :: acc
@@ -172,9 +175,19 @@ let rec resolve_columns env expr =
       let attr = try Schema.find env.insert_schema name with Schema.Error (_,s) -> fail "for inserted values : %s" s in
       ResValue attr.domain
     | Param x -> ResParam x
-    | InTupleList (cols, param_id) -> 
-      let schema = List.map (fun col -> (resolve_column env.tables env.schema col).attr) cols in
-      ResInTupleList (param_id, schema)
+    | InTupleList (exprs, param_id) -> 
+      let res_exprs = List.map (fun expr ->
+        let res_expr = each expr in
+        match res_expr with 
+        | ResValue _
+        | ResParam _
+        | ResFun _ -> res_expr
+        | ResInparam _
+        | ResChoices _
+        | ResInTupleList _
+        | ResInChoice _ -> fail "unsupported expression %s kind for WHERE e IN @tuplelist" (show_res_expr res_expr)
+      ) exprs in
+      ResInTupleList (param_id, Res res_exprs)
     | Inparam x -> ResInparam x
     | InChoice (n, k, x) -> ResInChoice (n, k, each x)
     | Choices (n,l) -> ResChoices (n, List.map (fun (n,e) -> n, Option.map each e) l)
@@ -186,7 +199,7 @@ let rec resolve_columns env expr =
         | SingleIn p -> [ResParam p]
         | ChoiceIn { vars; _ } -> as_params vars
         | Choice (_,l) -> l |> flat_map (function Simple (_, vars) -> Option.map_default as_params [] vars | Verbatim _ -> [])
-        | TupleList (p, _, _) -> failed ~at:p.pos "FIXME TupleList in SELECT subquery"
+        | TupleList (p, _) -> failed ~at:p.pos "FIXME TupleList in SELECT subquery"
       and as_params p = flat_map params_of_var p in
       let (schema,p,_) = eval_select_full env select in
       let schema = Schema.Source.from_schema schema in
@@ -199,14 +212,24 @@ let rec resolve_columns env expr =
   each expr
 
 (** assign types to parameters where possible *)
-and assign_types { set_tyvar_strict; _ } expr =
+and assign_types env expr =
+  let { set_tyvar_strict; _ } = env in
   let option_split = function None -> None, None | Some (x,y) -> Some x, Some y in
   let rec typeof_ (e:res_expr) = (* FIXME simplify *)
     match e with
     | ResValue t -> e, `Ok t
     | ResParam p -> e, `Ok p.typ
     | ResInparam p -> e, `Ok p.typ
-    | ResInTupleList _ -> e, `Ok (Type.strict Bool)
+    | ResInTupleList (param_id, kind) -> 
+      (match kind with 
+      | Res res_exprs -> ResInTupleList (param_id, ResTyped (List.map (fun expr ->
+         let typ = expr |> typeof |> snd |> get_or_failwith in 
+         if Type.is_any typ then 
+            fail "If you need to have a field as parameter in the left part you should specify a type"
+         else typ
+        ) res_exprs)), `Ok (Type.strict Bool) 
+      | ResTyped _ -> assert false
+      )
     | ResInChoice (n, k, e) -> let e, t = typeof e in ResInChoice (n, k, e), t
     | ResChoices (n,l) ->
       let (e,t) = List.split @@ List.map (fun (_,e) -> option_split @@ Option.map typeof e) l in
@@ -555,7 +578,7 @@ let rec eval (stmt:Sql.stmt) =
     let expect = values_or_all table names in
     let schema = List.map (fun attr -> { Schema.Source.Attr.sources=[table]; attr }) (Tables.get_schema table) in
     let env = { empty_env with tables = [Tables.get table]; schema; insert_schema = expect; } in
-    let params = [ TupleList (param_id, expect, Insertion) ] in
+    let params = [ TupleList (param_id, Insertion expect) ] in
     let params2 = params_of_assigns env (Option.default [] on_duplicate) in
     [], params @ params2, Insert (None, table)
   | Insert { target=table; action=`Select (names, select); on_duplicate; } ->

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -73,7 +73,7 @@ type sql =
   | Dynamic of (Sql.param_id * (Sql.param_id * Sql.var list option * sql list) list)
   | SubstIn of Sql.param
   | DynamicIn of Sql.param_id * [`In | `NotIn] * sql list
-  | SubstTuple of Sql.param_id * Sql.schema * Sql.tuple_list_kind
+  | SubstTuple of Sql.param_id * Sql.tuple_list_kind
 
 let substitute_vars s vars subst_param =
   let rec loop acc i parami vars =
@@ -131,11 +131,11 @@ let substitute_vars s vars subst_param =
       assert (i1 > i);
       let acc = Dynamic (name, dyn) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
       loop acc i2 parami tl
-    | TupleList (id, schema, kind) :: tl ->
+    | TupleList (id, kind) :: tl ->
       let (i1,i2) = id.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc = SubstTuple (id, schema, kind) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
+      let acc = SubstTuple (id, kind) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
       loop acc i2 parami tl
   in
   let (acc,last) = loop [] 0 0 vars in
@@ -211,7 +211,7 @@ let rec find_param_ids l =
       | Sql.Single p | SingleIn p -> [ p.id ]
       | Choice (id,_) -> [ id ]
       | ChoiceIn { param; vars; _ } -> find_param_ids vars @ [param]
-      | TupleList (id, _, _) -> [ id ])
+      | TupleList (id, _) -> [ id ])
     l
 
 let names_of_vars l =

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -356,6 +356,11 @@ let gen_tuple_substitution label schema =
     (gen_tuple_printer label schema)
     label 
 
+let make_schema_of_tuple_types label =
+  List.mapi (fun idx domain -> {
+    name=(sprintf "%s_%Ln" label idx); domain; extra = Constraints.empty
+  })   
+
 let make_sql l =
   let b = Buffer.create 100 in
   let rec loop app = function
@@ -391,11 +396,9 @@ let make_sql l =
     | SubstTuple (id, Where_in types) :: tl ->
       if app then bprintf b " ^ ";
       let label = resolve_tuple_label id in
-      let attrs = List.mapi (fun idx domain -> {
-        name=(sprintf "%s_%Ln" label idx); domain; extra = Constraints.empty
-      }) types in
+      let schema = make_schema_of_tuple_types label types in
       bprintf b "%s ^ " (quote "(");
-      Buffer.add_string b (gen_tuple_substitution label attrs);
+      Buffer.add_string b (gen_tuple_substitution label schema);
       bprintf b " ^ %s" (quote ")");
       loop true tl  
   in

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -60,7 +60,11 @@ let value ?(inparam=false) v =
 let tuplelist_value_of_param = function
   | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ -> None
   | TupleList ({ label = None; _ }, _) -> failwith "empty label in tuple subst"
-  | TupleList ({ label = Some name; _ }, _) ->
+  | TupleList ({ label = Some name; _ }, kind) ->
+    let schema = match kind with 
+    | Insertion schema -> schema 
+    | Where_in types -> Gen_caml.make_schema_of_tuple_types name types
+    in
     let typ = "list(" ^ String.concat ", " (List.map (fun { Sql.domain; _ } -> Sql.Type.type_name domain) schema) ^ ")" in
     let attrs = ["name", name; "type", typ] in
     Some (Node ("value", attrs, []))

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -59,8 +59,8 @@ let value ?(inparam=false) v =
 
 let tuplelist_value_of_param = function
   | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ -> None
-  | TupleList ({ label = None; _ }, _) -> failwith "empty label in tuple subst"
-  | TupleList ({ label = Some name; _ }, schema) ->
+  | TupleList ({ label = None; _ }, _, _) -> failwith "empty label in tuple subst"
+  | TupleList ({ label = Some name; _ }, schema, _) ->
     let typ = "list(" ^ String.concat ", " (List.map (fun { Sql.domain; _ } -> Sql.Type.type_name domain) schema) ^ ")" in
     let attrs = ["name", name; "type", typ] in
     Some (Node ("value", attrs, []))
@@ -81,7 +81,7 @@ let get_sql_string stmt =
   let rec map i = function
   | Static s -> s
   | SubstIn param -> "@@" ^ show_param_name param i (* TODO join text and prepared params earlier for single indexing *)
-  | SubstTuple (id, _) -> "@@@" ^ make_param_name i id
+  | SubstTuple (id, _, _) -> "@@@" ^ make_param_name i id
   | DynamicIn (_p, _, sqls) -> String.concat "" @@ List.map (map 0 ) sqls
   | Dynamic _ -> "{TODO dynamic choice}"
   in

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -59,8 +59,8 @@ let value ?(inparam=false) v =
 
 let tuplelist_value_of_param = function
   | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ -> None
-  | TupleList ({ label = None; _ }, _, _) -> failwith "empty label in tuple subst"
-  | TupleList ({ label = Some name; _ }, schema, _) ->
+  | TupleList ({ label = None; _ }, _) -> failwith "empty label in tuple subst"
+  | TupleList ({ label = Some name; _ }, _) ->
     let typ = "list(" ^ String.concat ", " (List.map (fun { Sql.domain; _ } -> Sql.Type.type_name domain) schema) ^ ")" in
     let attrs = ["name", name; "type", typ] in
     Some (Node ("value", attrs, []))
@@ -81,7 +81,7 @@ let get_sql_string stmt =
   let rec map i = function
   | Static s -> s
   | SubstIn param -> "@@" ^ show_param_name param i (* TODO join text and prepared params earlier for single indexing *)
-  | SubstTuple (id, _, _) -> "@@@" ^ make_param_name i id
+  | SubstTuple (id, _) -> "@@@" ^ make_param_name i id
   | DynamicIn (_p, _, sqls) -> String.concat "" @@ List.map (map 0 ) sqls
   | Dynamic _ -> "{TODO dynamic choice}"
   in

--- a/src/test.ml
+++ b/src/test.ml
@@ -269,6 +269,16 @@ let test_param_not_null_by_default = [
   ];
 ]
 
+(* Since @abc is tuple list, but TupleList isn't a Sql.type *)
+let test_in_clause_with_tuple_sets () = 
+  do_test "CREATE TABLE test17 (a INT, b INT NULL, c TEXT NULL)" [] [];
+  let stmt = parse {| 
+    SELECT a FROM test17 
+    WHERE (a, b, c) IN @abc
+  |} in
+  assert_equal ~msg:"schema" ~printer:Sql.Schema.to_string [attr' ~nullability:(Nullable) "a" Int] stmt.schema;
+  ()
+
 let run () =
   Gen.params_mode := Some Named;
   let tests =
@@ -286,6 +296,7 @@ let run () =
     "test_not_null_default_field" >::: test_not_null_default_field;
     "test_update_join" >::: test_update_join;
     "test_param_not_null_by_default" >::: test_param_not_null_by_default;
+    "test_in_clause_with_tuple_sets" >:: test_in_clause_with_tuple_sets;
   ]
   in
   let test_suite = "main" >::: tests in

--- a/test/out/where_in_tuple_list.xml
+++ b/test/out/where_in_tuple_list.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_table1" sql="CREATE TABLE table1 (&#x0A;  col1 TEXT NULL,&#x0A;  col2 INT NULL&#x0A;)" category="DDL" kind="create" target="table1" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_1" sql="SELECT `col1`, `col2`&#x0A;FROM `table1`&#x0A;WHERE (1, col1, col2, col1 + col1, 6, 11, (@test3 :: Text)) IN @@@in_ AND col2 &gt; 3" category="DQL" kind="select" cardinality="n">
+  <in>
+   <value name="in_" type="list(Int, Text, Int, Text, Int, Int, Text)"/>
+  </in>
+  <out>
+   <value name="col1" type="Text" nullable="true"/>
+   <value name="col2" type="Int" nullable="true"/>
+  </out>
+ </stmt>
+ <table name="table1">
+  <schema>
+   <value name="col1" type="Text" nullable="true"/>
+   <value name="col2" type="Int" nullable="true"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/where_in_tuple_list.sql
+++ b/test/where_in_tuple_list.sql
@@ -1,0 +1,8 @@
+CREATE TABLE table1 (
+  col1 TEXT NULL,
+  col2 INT NULL
+);
+
+SELECT `col1`, `col2`
+FROM `table1`
+WHERE (1, col1, col2, col1 + col1, 6, 11, (@test3 :: Text)) IN @in_ AND col2 > 3;


### PR DESCRIPTION
### Description
This PR adds a support for the WHERE IN with `@tuple` list expression.

Example:

```sql
SELECT `col1`, `col2`
FROM `table1`
WHERE (1, col1, col2, col1 + col1, 6, 11, (@test3 :: Text)) IN @in_ AND col2 > 3;
```

If we need to have a parameter on the left side (before the IN expr), how  `@test3` is, We should specify a type.