### PR TITLE
Consider `GROUP BY` and nested queries when `Agg`regation

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -35,6 +35,8 @@ struct
 
   let make_strict { t; nullability=_ } = strict t
 
+  let is_strict { nullability; _ } = nullability = Strict
+
   let (=) : t -> t -> bool = equal
 
   let show { t; nullability; } = show_kind t ^ (match nullability with Nullable -> "?" | Depends -> "??" | Strict -> "")
@@ -135,6 +137,10 @@ struct
   let string_of_func = Format.asprintf "%a" pp_func
 
   let is_grouping = function
+  | Group _ | Agg -> true
+  | Ret _ | F _ | Multi _ | Coalesce _  | Comparison -> false
+
+  let is_agg = function 
   | Group _ | Agg -> true
   | Ret _ | F _ | Multi _ | Coalesce _  | Comparison -> false
 end

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -139,10 +139,6 @@ struct
   let is_grouping = function
   | Group _ | Agg -> true
   | Ret _ | F _ | Multi _ | Coalesce _  | Comparison -> false
-
-  let is_agg = function 
-  | Group _ | Agg -> true
-  | Ret _ | F _ | Multi _ | Coalesce _  | Comparison -> false
 end
 
 module Constraint =

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -345,12 +345,12 @@ and assign_types env expr =
           | x -> x
         in
         ResFun (func,(List.map2 assign inferred_params params)), `Ok ret
-  and typeof ?(under_agg=false) expr =
+  and typeof ~under_agg expr =
     let r = typeof_ ~under_agg expr in
     if !debug then eprintfn "%s is typeof %s" (Type.show @@ get_or_failwith @@ snd r) (show_res_expr @@ fst r);
     r
   in
-  typeof expr
+  typeof ~under_agg:false expr
 
 and resolve_types env expr =
   let expr = resolve_columns env expr in


### PR DESCRIPTION
### Description
This PR adds a few conditionals to `Agg` nullability inferring that was added https://github.com/ahrefs/sqlgg/pull/18 here.

1) The presence of `GROUP BY` + type of expression isn't `NULL`able = strict result of `Agg`
2) Any nested queries (`SelectExpr`s) are considered `NULL`able even if the column is strict because it is possible to have no rows result, which is literally equal to `NULL`.

[Tests](https://github.com/ahrefs/sqlgg/pull/19/files#diff-8ea9ba782f39d6a4f13234e5c57b9662624994b402b68b3b1e62bd255f7e10b5R290-R328) will give more understanding