### PR TITLE
Make the ambiguous check the same as in runtime

### DIFF
--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -126,11 +126,11 @@ let exists_grouping columns =
 (* FIXME check type of duplicates *)
 let make_unique =
   List.unique ~cmp:(fun a1 a2 ->
-      (* Check if alias has same name as column OR if columns are from the same table (source)  *)
-      (a2.Schema.Source.Attr.sources = [] || a1.Schema.Source.Attr.sources = a2.sources)
-      && a1.attr.name = a2.attr.name
-      (* Check if the tested column is unnamed (not a column) and unaliased *)
-      && a1.attr.name <> "")
+    (* Check if columns are from the same table (source)  *)
+    a1.Schema.Source.Attr.sources = a2.sources
+    && a1.attr.name = a2.attr.name
+    (* Check if columns are named *)
+    && a1.attr.name <> "")
 
 let all_columns = make_unique $ Schema.cross_all
 
@@ -205,9 +205,7 @@ let resolve_aggregations =
   handle ~is_agg:false 
   
 let update_schema_with_aliases all_schema final_schema = 
-  let applied = List.filter (fun s1 ->
-    List.for_all (fun s2 -> s2.Schema.Source.Attr.attr.name <> s1.Schema.Source.Attr.attr.name) final_schema
-  ) all_schema in 
+  let applied = all_schema |> List.filter (fun s1 -> List.for_all Schema.Source.Attr.(fun s2 -> s2.attr.name <> s1.attr.name) final_schema) in  
   applied @ final_schema
 
 (** resolve each name reference (Column, Inserted, etc) into ResValue or ResFun of corresponding type *)
@@ -506,7 +504,10 @@ and eval_select env { columns; from; where; group; having; } =
   let p1 = get_params_of_columns env columns in
   let env = { env with schema = make_unique (Schema.Join.cross env.schema final_schema) } in (* enrich schema in scope with aliases *)
   (* WHERE requires explicit column source when ambiguous fields are present *)
-  let p3 = get_params_opt { env with set_tyvar_strict = true; } where in
+  let p3 = get_params_opt { env with set_tyvar_strict = true; 
+    (* Aliases aren't available on the WHERE stage *)
+    schema = List.filter (fun i -> i.Schema.Source.Attr.sources <> []) env.schema; 
+  } where in
   (* ORDER BY, HAVING, GROUP BY allow have column without explicit referring to source if it's specified in SELECT *)
   let env = { env with schema = update_schema_with_aliases env.schema final_schema } in
   let p4 = get_params_l env group in
@@ -534,8 +535,8 @@ and resolve_source env (x,alias) =
 and eval_select_full env { select_complete; cte } =
   let ctes, p1 = Option.map_default eval_cte ([], []) cte in
   let env = { env with ctes = ctes @ env.ctes } in
-  let (s1, p2, tbls, cardinality) = eval_select env (fst @@ select_complete.select) in
-  eval_compound ~env:{ env with tables = tbls; } (p1 @ p2, s1, cardinality, select_complete)
+  let (s1, p2, env, cardinality) = eval_select env (fst @@ select_complete.select) in
+  eval_compound ~env:{ env with tables = env.tables; } (p1 @ p2, s1, cardinality, select_complete)
 
 and eval_cte { cte_items; is_recursive } = 
   let open Schema.Source in
@@ -555,17 +556,17 @@ and eval_cte { cte_items; is_recursive } =
         end
         in
         let stmt = { cte.stmt with select = select, other } in
-        let s1, p1, tbls, cardinality = eval_select env (fst stmt.select) in
+        let s1, p1, env, cardinality = eval_select env (fst stmt.select) in
         (* UNIONed fields access by alias to itself cte *)
         let s2 = Schema.compound (Option.map_default a1 s1 cte.cols) s1 in
         let a2 = from_schema s2 in
         eval_compound
-          ~env:{ env with tables = tbls; ctes = (tbl_name, a2) :: env.ctes } 
+          ~env:{ env with ctes = (tbl_name, a2) :: env.ctes } 
           (p1, s1, cardinality, stmt)
       end    
       else (
-        let s1, p1, tbls, cardinality = eval_select env (fst cte.stmt.select) in
-        eval_compound ~env:{ env with tables = tbls } (p1, s1, cardinality, cte.stmt))
+        let s1, p1, env, cardinality = eval_select env (fst cte.stmt.select) in
+        eval_compound ~env:{ env with tables = env.tables } (p1, s1, cardinality, cte.stmt))
     in
     let s2 = Schema.compound (Option.map_default a1 s1 cte.cols) s1 in
     (tbl_name, from_schema s2) :: acc_ctes, p1 @ acc_vars end
@@ -579,7 +580,7 @@ and eval_compound ~env result =
   let cardinality = if other = [] then cardinality else `Nat in
   (* ignoring tables in compound statements - they cannot be used in ORDER BY *)
   let final_schema = List.fold_left Schema.compound s1 s2l in
-  let p3 = params_of_order order final_schema env.tables in
+  let p3 = params_of_order order final_schema env in
   let (p4,limit1) = match limit with Some (p,x) -> List.map (fun p -> Single p) p, x | None -> [],false in
   (*                 Schema.check_unique schema; *)
   let cardinality =
@@ -726,7 +727,7 @@ let rec eval (stmt:Sql.stmt) =
     let r = List.map (fun attr -> {Schema.Source.Attr.attr; sources=[f] }) s in
 
     let params = update_tables ~env:empty_env [r,[],[(f, s)]] ss w in
-    let p3 = params_of_order o [] [(f, s)] in
+    let p3 = params_of_order o [] { empty_env with tables = [(f, s)] } in
     [], params @ p3 @ (List.map (fun p -> Single p) lim), Update (Some table)
   | UpdateMulti (tables,ss,w) ->
     let sources = List.map (fun src -> resolve_source empty_env ((`Nested src), None)) tables in

--- a/src/test.ml
+++ b/src/test.ml
@@ -207,7 +207,7 @@ let test_coalesce = [
   tt "SELECT COALESCE(x, coalesce(null, null, 75, null), null) as x FROM test8" [attr' ~nullability:Strict "x" Int;] [];
 ]
 
-let test_coalesce = [
+let test_primary_strict = [
   tt "CREATE TABLE test9 (x BIGINT UNSIGNED PRIMARY KEY)" [] [];
   tt "SELECT x FROM test9 WHERE x > 100" [attr' ~extra:[PrimaryKey] ~nullability:(Strict) "x" Int;] [];
 ]
@@ -503,6 +503,7 @@ let run () =
     "manual_param" >::: test_manual_param;
     "test_left_join" >::: test_left_join;
     "test_coalesce" >::: test_coalesce;
+    "test_primary_strict" >::: test_primary_strict;
     "test_not_null_default_field" >::: test_not_null_default_field;
     "test_update_join" >::: test_update_join;
     "test_param_not_null_by_default" >::: test_param_not_null_by_default;

--- a/src/test.ml
+++ b/src/test.ml
@@ -359,121 +359,7 @@ let test_agg_nullable = [
   |} [ attr' "result" Int; ][];
 ]
 
-<<<<<<< HEAD
 let cte_possible_rec_non_shared_select_only = [
-||||||| parent of dab6cce (fix ambiguous test, make clearly update_schema_with_aliases)
-let test_ambiguous = [
-  tt "CREATE TABLE test21 (id INT, column_a TEXT, column_b BOOL)" [] [];
-  tt "CREATE TABLE test22 (id INT, column_d INT)" [] [];
-  wrong "select id from test21 join test22 on test21.id = test22.id order by id";
-  tt "select test21.id from test21 join test22 on test21.id = test22.id order by id" [
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  wrong "select test21.id from test21 join test22 on test21.id = test22.id where id > 2 order by id";
-  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id" [
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  tt "select test21.id as test from test21 join test22 on test21.id = test22.id group by column_a" [
-    attr' ~nullability:(Nullable) "test" Int;
-  ][];
-  tt "select test21.id, test22.id from test21 join test22 on test21.id = test22.id" [
-    attr' ~nullability:(Nullable) "id" Int;
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  wrong "select id, id from test21 join test22 on test21.id = test22.id group by id";
-  wrong "select test21.id, test22.id from test21 join test22 on test21.id = test22.id group by id";
-  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id, column_a" [
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  tt "SELECT COUNT(column_a) as column_a FROM test21 WHERE column_a = @column_a" [
-    attr' "column_a" Int;
-  ] [
-    named "column_a" Int;
-  ];
-  wrong "select * from test21 join test22 on test21.id = test22.id group by id" ;
-  tt "CREATE TABLE test23 (id INT)" [] [];
-  tt "CREATE TABLE test24 (id INT)" [] [];
-  wrong "select * from foo join bar on foo.id = bar.id order by id";
-  wrong "select * from foo join bar on foo.id";
-  tt "SELECT test21.id AS id, test22.id AS id FROM test21 JOIN test22 ON test21.id = test22.id" [
-    attr' ~nullability:(Nullable) "id" Int;
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  tt "SELECT test21.id, test22.id FROM test21 JOIN test22 ON test21.id = test22.id GROUP BY test21.id" [
-    attr' ~nullability:(Nullable) "id" Int;
-    attr' ~nullability:(Nullable) "id" Int;
-  ][];
-  wrong "SELECT COUNT(id) FROM test21 JOIN test22 ON test21.id = test22.id";
-  wrong "SELECT COUNT(id) as id FROM test21 JOIN test22 ON test21.id = test22.id";
-  wrong "SELECT id FROM test21 JOIN test22 ON test21.id = test22.id WHERE id > 2";
-  tt "SELECT test21.id AS test_id, test22.id AS other_id FROM test21 JOIN test22 ON test21.id = test22.id" [
-    attr' ~nullability:(Nullable) "test_id" Int;
-    attr' ~nullability:(Nullable) "other_id" Int;
-  ] [];
-  tt "SELECT COUNT(test21.id) AS count_id FROM test21 JOIN test22 ON test21.id = test22.id" [
-    attr' "count_id" Int;
-  ] [];
-  tt "CREATE TABLE test25 (id INT, value INT)" [] [];
-  tt "CREATE TABLE test26 (id INT, value INT)" [] [];
-  tt "CREATE TABLE test27 (id INT, value INT)" [] [];
-=======
-let test_ambiguous = [
-  tt "CREATE TABLE test21 (id INT, column_a TEXT, column_b BOOL)" [] [];
-  tt "CREATE TABLE test22 (id INT, column_d INT)" [] [];
-  wrong "select id from test21 join test22 on test21.id = test22.id order by id";
-  tt "select test21.id from test21 join test22 on test21.id = test22.id order by id" [
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  (* Wrong parses and asserts fail *)
-  wrong "select test21.id from test21 join test22 on test21.id = test22.id where id > 2 order by id";
-  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id" [
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  tt "select test21.id as test from test21 join test22 on test21.id = test22.id group by column_a" [
-    attr' ~nullability:(Nullable) "test" Int;
-  ][];
-  tt "select test21.id, test22.id from test21 join test22 on test21.id = test22.id" [
-    attr' ~nullability:(Nullable) "id" Int;
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  (* Wrong parses and asserts fail *)
-  wrong "select id, id from test21 join test22 on test21.id = test22.id group by id";
-  wrong "select id as id1, id as id2 from test21 join test22 on test21.id = test22.id group by id";
-  wrong "select test21.id, test22.id from test21 join test22 on test21.id = test22.id group by id";
-  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id, column_a" [
-    attr' ~nullability:(Nullable) "id" Int;
-  ] [];
-  tt "SELECT COUNT(column_a) as column_a FROM test21 WHERE column_a = @column_a" [
-    attr' "column_a" Int;
-  ] [
-    named "column_a" Int;
-  ];
-  wrong "select * from test21 join test22 on test21.id = test22.id group by id" ;
-  tt "CREATE TABLE test23 (id INT)" [] [];
-  tt "CREATE TABLE test24 (id INT)" [] [];
-  wrong "select * from foo join bar on foo.id";
-  tt "SELECT test21.id AS id1, test22.id AS id2 FROM test21 JOIN test22 ON test21.id = test22.id" [
-    attr' ~nullability:(Nullable) "id1" Int;
-    attr' ~nullability:(Nullable) "id2" Int;
-  ] [];
-  tt "SELECT test21.id, test22.id FROM test21 JOIN test22 ON test21.id = test22.id GROUP BY test21.id" [
-    attr' ~nullability:(Nullable) "id" Int;
-    attr' ~nullability:(Nullable) "id" Int;
-  ][];
-  wrong "SELECT COUNT(id) FROM test21 JOIN test22 ON test21.id = test22.id";
-  wrong "SELECT COUNT(id) as id FROM test21 JOIN test22 ON test21.id = test22.id";
-  wrong "SELECT id FROM test21 JOIN test22 ON test21.id = test22.id WHERE id > 2";
-  tt "SELECT test21.id AS test_id, test22.id AS other_id FROM test21 JOIN test22 ON test21.id = test22.id" [
-    attr' ~nullability:(Nullable) "test_id" Int;
-    attr' ~nullability:(Nullable) "other_id" Int;
-  ] [];
-  tt "SELECT COUNT(test21.id) AS count_id FROM test21 JOIN test22 ON test21.id = test22.id" [
-    attr' "count_id" Int;
-  ] [];
-  tt "CREATE TABLE test25 (id INT, value INT)" [] [];
-  tt "CREATE TABLE test26 (id INT, value INT)" [] [];
-  tt "CREATE TABLE test27 (id INT, value INT)" [] [];
->>>>>>> dab6cce (fix ambiguous test, make clearly update_schema_with_aliases)
   tt {|
     WITH RECURSIVE sequence_cte AS (
       SELECT 1 AS num
@@ -604,6 +490,85 @@ let test_ambiguous = [
   |};
 ]
 
+let test_ambiguous = [
+  tt "CREATE TABLE test23 (id INT, column_a TEXT, column_b BOOL)" [] [];
+  tt "CREATE TABLE test24 (id INT, column_d INT)" [] [];
+  wrong "select id from test23 join test24 on test23.id = test24.id order by id";
+  (* The difference between this example, and the same but with WHERE (following "wrong" fn) is
+     sql engine uses those columns that were mentioned in the SELECT statement, 
+     while it doesn't do that for WHERE.
+  *)
+  tt "select test23.id from test23 join test24 on test23.id = test24.id order by id" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  (* Wrong parses and asserts fail *)
+  wrong "select test23.id from test23 join test24 on test23.id = test24.id where id > 2 order by id";
+  tt "select test23.id from test23 join test24 on test23.id = test24.id group by id" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "select test23.id as test from test23 join test24 on test23.id = test24.id group by column_a" [
+    attr' ~nullability:(Nullable) "test" Int;
+  ][];
+  tt "select test23.id, test24.id from test23 join test24 on test23.id = test24.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  (* Wrong parses and asserts fail *)
+  wrong "select id, id from test23 join test24 on test23.id = test24.id group by id";
+  wrong "select id as id1, id as id2 from test23 join test24 on test23.id = test24.id group by id";
+  wrong "select test23.id, test24.id from test23 join test24 on test23.id = test24.id group by id";
+  tt "select test23.id from test23 join test24 on test23.id = test24.id group by id, column_a" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "SELECT COUNT(column_a) as column_a FROM test23 WHERE column_a = @column_a" [
+    (* COUNT(column_a :: Text) :: Int *)
+    attr' "column_a" Int;
+  ] [
+    named "column_a" Text;
+  ];
+  wrong "select * from test23 join test24 on test23.id = test24.id group by id" ;
+  tt "CREATE TABLE test25 (id INT)" [] [];
+  tt "CREATE TABLE test26 (id INT)" [] [];
+  wrong "select * from foo join bar on foo.id";
+  tt "SELECT test23.id AS id1, test24.id AS id2 FROM test23 JOIN test24 ON test23.id = test24.id" [
+    attr' ~nullability:(Nullable) "id1" Int;
+    attr' ~nullability:(Nullable) "id2" Int;
+  ] [];
+  tt "SELECT test23.id, test24.id FROM test23 JOIN test24 ON test23.id = test24.id GROUP BY test23.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ][];
+  wrong "SELECT COUNT(id) FROM test23 JOIN test24 ON test23.id = test24.id";
+  wrong "SELECT COUNT(id) as id FROM test23 JOIN test24 ON test23.id = test24.id";
+  wrong "SELECT id FROM test23 JOIN test24 ON test23.id = test24.id WHERE id > 2";
+  tt "SELECT test23.id AS test_id, test24.id AS other_id FROM test23 JOIN test24 ON test23.id = test24.id" [
+    attr' ~nullability:(Nullable) "test_id" Int;
+    attr' ~nullability:(Nullable) "other_id" Int;
+  ] [];
+  tt "SELECT COUNT(test23.id) AS count_id FROM test23 JOIN test24 ON test23.id = test24.id" [
+    attr' "count_id" Int;
+  ] [];
+  tt "CREATE TABLE test27 (id INT, value INT)" [] [];
+  tt "CREATE TABLE test28 (id INT, value INT)" [] [];
+  tt "CREATE TABLE test29 (id INT, value INT)" [] [];
+  tt {|
+    SELECT t1.id AS id_from_test27, t2.value AS value_from_test28, t3.value AS value_from_test29
+    FROM test27 t1
+    JOIN test28 t2 ON t1.id = t2.id
+    JOIN test29 t3 ON t1.id = t3.id
+  |}[
+    attr' ~nullability:(Nullable) "id_from_test27" Int;
+    attr' ~nullability:(Nullable) "value_from_test28" Int;
+    attr' ~nullability:(Nullable) "value_from_test29" Int;
+  ][];
+  (* In WHERE aliases aren't available *)
+  wrong {|
+    SELECT MAX(id) AS max_id
+    FROM test23
+    WHERE max_id > 0
+  |};  
+]
+
 let run () =
   Gen.params_mode := Some Named;
   let tests =
@@ -625,6 +590,7 @@ let run () =
     "test_in_clause_with_tuple_sets" >:: test_in_clause_with_tuple_sets;
     "test_agg_nullable" >::: test_agg_nullable;
     "cte_possible_rec_non_shared_select_only" >::: cte_possible_rec_non_shared_select_only;
+    "test_ambiguous" >::: test_ambiguous;
   ]
   in
   let test_suite = "main" >::: tests in

--- a/src/test.ml
+++ b/src/test.ml
@@ -51,7 +51,7 @@ let test = Type.[
   tt "SELECT str FROM test WHERE id=?"
      [attr' ~nullability:(Nullable) "str" Text]
      [param Int];
-   tt "SELECT x,y+? AS z FROM (SELECT id AS y,CONCAT(str,name) AS x FROM test WHERE id=@id*2) ORDER BY x,x+z LIMIT @lim"
+  tt "SELECT x,y+? AS z FROM (SELECT id AS y,CONCAT(str,name) AS x FROM test WHERE id=@id*2) ORDER BY x,x+z LIMIT @lim"
      [attr' "x" Text; attr' ~nullability:(Nullable) "z" Int]
      [param_nullable Int; named "id" Int; named "lim" Int; ];
   tt "select test.name,other.name as other_name from test, test as other where test.id=other.id + @delta"
@@ -89,7 +89,8 @@ let test = Type.[
 
 let test2 = [
   tt "CREATE TABLE test2 (id INT, str TEXT)" [] [];
-  tt    "update test, (select * from test2) as x set str = x.str where test.id=x.id" [] [];
+  (* Column 'str' in field list is ambiguous *)
+  wrong "update test, (select * from test2) as x set str = x.str where test.id=x.id";
   tt    "update test, (select * from test2) as x set name = x.str where test.id=x.id" [] [];
   tt    "update test, (select * from test2) as x set test.str = x.str where test.id=x.id" [] [];
   wrong "update test, (select * from test2) as x set test.name = x.name where test.id=x.id";

--- a/src/test.ml
+++ b/src/test.ml
@@ -359,7 +359,121 @@ let test_agg_nullable = [
   |} [ attr' "result" Int; ][];
 ]
 
+<<<<<<< HEAD
 let cte_possible_rec_non_shared_select_only = [
+||||||| parent of dab6cce (fix ambiguous test, make clearly update_schema_with_aliases)
+let test_ambiguous = [
+  tt "CREATE TABLE test21 (id INT, column_a TEXT, column_b BOOL)" [] [];
+  tt "CREATE TABLE test22 (id INT, column_d INT)" [] [];
+  wrong "select id from test21 join test22 on test21.id = test22.id order by id";
+  tt "select test21.id from test21 join test22 on test21.id = test22.id order by id" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  wrong "select test21.id from test21 join test22 on test21.id = test22.id where id > 2 order by id";
+  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "select test21.id as test from test21 join test22 on test21.id = test22.id group by column_a" [
+    attr' ~nullability:(Nullable) "test" Int;
+  ][];
+  tt "select test21.id, test22.id from test21 join test22 on test21.id = test22.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  wrong "select id, id from test21 join test22 on test21.id = test22.id group by id";
+  wrong "select test21.id, test22.id from test21 join test22 on test21.id = test22.id group by id";
+  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id, column_a" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "SELECT COUNT(column_a) as column_a FROM test21 WHERE column_a = @column_a" [
+    attr' "column_a" Int;
+  ] [
+    named "column_a" Int;
+  ];
+  wrong "select * from test21 join test22 on test21.id = test22.id group by id" ;
+  tt "CREATE TABLE test23 (id INT)" [] [];
+  tt "CREATE TABLE test24 (id INT)" [] [];
+  wrong "select * from foo join bar on foo.id = bar.id order by id";
+  wrong "select * from foo join bar on foo.id";
+  tt "SELECT test21.id AS id, test22.id AS id FROM test21 JOIN test22 ON test21.id = test22.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "SELECT test21.id, test22.id FROM test21 JOIN test22 ON test21.id = test22.id GROUP BY test21.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ][];
+  wrong "SELECT COUNT(id) FROM test21 JOIN test22 ON test21.id = test22.id";
+  wrong "SELECT COUNT(id) as id FROM test21 JOIN test22 ON test21.id = test22.id";
+  wrong "SELECT id FROM test21 JOIN test22 ON test21.id = test22.id WHERE id > 2";
+  tt "SELECT test21.id AS test_id, test22.id AS other_id FROM test21 JOIN test22 ON test21.id = test22.id" [
+    attr' ~nullability:(Nullable) "test_id" Int;
+    attr' ~nullability:(Nullable) "other_id" Int;
+  ] [];
+  tt "SELECT COUNT(test21.id) AS count_id FROM test21 JOIN test22 ON test21.id = test22.id" [
+    attr' "count_id" Int;
+  ] [];
+  tt "CREATE TABLE test25 (id INT, value INT)" [] [];
+  tt "CREATE TABLE test26 (id INT, value INT)" [] [];
+  tt "CREATE TABLE test27 (id INT, value INT)" [] [];
+=======
+let test_ambiguous = [
+  tt "CREATE TABLE test21 (id INT, column_a TEXT, column_b BOOL)" [] [];
+  tt "CREATE TABLE test22 (id INT, column_d INT)" [] [];
+  wrong "select id from test21 join test22 on test21.id = test22.id order by id";
+  tt "select test21.id from test21 join test22 on test21.id = test22.id order by id" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  (* Wrong parses and asserts fail *)
+  wrong "select test21.id from test21 join test22 on test21.id = test22.id where id > 2 order by id";
+  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "select test21.id as test from test21 join test22 on test21.id = test22.id group by column_a" [
+    attr' ~nullability:(Nullable) "test" Int;
+  ][];
+  tt "select test21.id, test22.id from test21 join test22 on test21.id = test22.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  (* Wrong parses and asserts fail *)
+  wrong "select id, id from test21 join test22 on test21.id = test22.id group by id";
+  wrong "select id as id1, id as id2 from test21 join test22 on test21.id = test22.id group by id";
+  wrong "select test21.id, test22.id from test21 join test22 on test21.id = test22.id group by id";
+  tt "select test21.id from test21 join test22 on test21.id = test22.id group by id, column_a" [
+    attr' ~nullability:(Nullable) "id" Int;
+  ] [];
+  tt "SELECT COUNT(column_a) as column_a FROM test21 WHERE column_a = @column_a" [
+    attr' "column_a" Int;
+  ] [
+    named "column_a" Int;
+  ];
+  wrong "select * from test21 join test22 on test21.id = test22.id group by id" ;
+  tt "CREATE TABLE test23 (id INT)" [] [];
+  tt "CREATE TABLE test24 (id INT)" [] [];
+  wrong "select * from foo join bar on foo.id";
+  tt "SELECT test21.id AS id1, test22.id AS id2 FROM test21 JOIN test22 ON test21.id = test22.id" [
+    attr' ~nullability:(Nullable) "id1" Int;
+    attr' ~nullability:(Nullable) "id2" Int;
+  ] [];
+  tt "SELECT test21.id, test22.id FROM test21 JOIN test22 ON test21.id = test22.id GROUP BY test21.id" [
+    attr' ~nullability:(Nullable) "id" Int;
+    attr' ~nullability:(Nullable) "id" Int;
+  ][];
+  wrong "SELECT COUNT(id) FROM test21 JOIN test22 ON test21.id = test22.id";
+  wrong "SELECT COUNT(id) as id FROM test21 JOIN test22 ON test21.id = test22.id";
+  wrong "SELECT id FROM test21 JOIN test22 ON test21.id = test22.id WHERE id > 2";
+  tt "SELECT test21.id AS test_id, test22.id AS other_id FROM test21 JOIN test22 ON test21.id = test22.id" [
+    attr' ~nullability:(Nullable) "test_id" Int;
+    attr' ~nullability:(Nullable) "other_id" Int;
+  ] [];
+  tt "SELECT COUNT(test21.id) AS count_id FROM test21 JOIN test22 ON test21.id = test22.id" [
+    attr' "count_id" Int;
+  ] [];
+  tt "CREATE TABLE test25 (id INT, value INT)" [] [];
+  tt "CREATE TABLE test26 (id INT, value INT)" [] [];
+  tt "CREATE TABLE test27 (id INT, value INT)" [] [];
+>>>>>>> dab6cce (fix ambiguous test, make clearly update_schema_with_aliases)
   tt {|
     WITH RECURSIVE sequence_cte AS (
       SELECT 1 AS num

--- a/test/ambiguous.sql
+++ b/test/ambiguous.sql
@@ -1,0 +1,53 @@
+CREATE TABLE test28 (
+    employee_id INT,
+    department_id INT,
+    salary DECIMAL(10, 2)
+);
+
+CREATE TABLE test29 (
+    department_id INT,
+    department_name VARCHAR(100)
+);
+
+CREATE TABLE test30 (
+    project_id INT,
+    department_id INT,
+    project_name VARCHAR(100)
+);
+
+CREATE TABLE test31 (
+    employee_id INT,
+    project_id INT
+);
+
+SELECT
+    d.department_name,
+    ds.total_salary,
+    COALESCE(pc.project_count, 0) AS project_count,
+    (ds.total_salary / NULLIF(COALESCE(pc.project_count, 0), 0)) AS avg_salary_per_project
+FROM
+    (
+        SELECT
+            e.department_id,
+            SUM(e.salary) AS total_salary
+        FROM
+            test28 e
+        GROUP BY
+            e.department_id
+    ) AS ds
+JOIN
+    (
+        SELECT
+            p.department_id,
+            COUNT(ep.project_id) AS project_count
+        FROM
+            test30 p
+        LEFT JOIN
+            test31 ep ON p.project_id = ep.project_id
+        GROUP BY
+            p.department_id
+    ) AS pc ON ds.department_id = pc.department_id
+JOIN
+    test29 d ON ds.department_id = d.department_id
+ORDER BY
+    ds.total_salary DESC;

--- a/test/out/ambiguous.xml
+++ b/test/out/ambiguous.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_test28" sql="CREATE TABLE test28 (&#x0A;    employee_id INT,&#x0A;    department_id INT,&#x0A;    salary DECIMAL(10, 2)&#x0A;)" category="DDL" kind="create" target="test28" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_test29" sql="CREATE TABLE test29 (&#x0A;    department_id INT,&#x0A;    department_name VARCHAR(100)&#x0A;)" category="DDL" kind="create" target="test29" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_test30" sql="CREATE TABLE test30 (&#x0A;    project_id INT,&#x0A;    department_id INT,&#x0A;    project_name VARCHAR(100)&#x0A;)" category="DDL" kind="create" target="test30" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_test31" sql="CREATE TABLE test31 (&#x0A;    employee_id INT,&#x0A;    project_id INT&#x0A;)" category="DDL" kind="create" target="test31" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_4" sql="SELECT&#x0A;    d.department_name,&#x0A;    ds.total_salary,&#x0A;    COALESCE(pc.project_count, 0) AS project_count,&#x0A;    (ds.total_salary / NULLIF(COALESCE(pc.project_count, 0), 0)) AS avg_salary_per_project&#x0A;FROM&#x0A;    (&#x0A;        SELECT&#x0A;            e.department_id,&#x0A;            SUM(e.salary) AS total_salary&#x0A;        FROM&#x0A;            test28 e&#x0A;        GROUP BY&#x0A;            e.department_id&#x0A;    ) AS ds&#x0A;JOIN&#x0A;    (&#x0A;        SELECT&#x0A;            p.department_id,&#x0A;            COUNT(ep.project_id) AS project_count&#x0A;        FROM&#x0A;            test30 p&#x0A;        LEFT JOIN&#x0A;            test31 ep ON p.project_id = ep.project_id&#x0A;        GROUP BY&#x0A;            p.department_id&#x0A;    ) AS pc ON ds.department_id = pc.department_id&#x0A;JOIN&#x0A;    test29 d ON ds.department_id = d.department_id&#x0A;ORDER BY&#x0A;    ds.total_salary DESC" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="department_name" type="Text" nullable="true"/>
+   <value name="total_salary" type="Decimal" nullable="true"/>
+   <value name="project_count" type="Int"/>
+   <value name="avg_salary_per_project" type="Float" nullable="true"/>
+  </out>
+ </stmt>
+ <table name="test31">
+  <schema>
+   <value name="employee_id" type="Int" nullable="true"/>
+   <value name="project_id" type="Int" nullable="true"/>
+  </schema>
+ </table>
+ <table name="test30">
+  <schema>
+   <value name="project_id" type="Int" nullable="true"/>
+   <value name="department_id" type="Int" nullable="true"/>
+   <value name="project_name" type="Text" nullable="true"/>
+  </schema>
+ </table>
+ <table name="test29">
+  <schema>
+   <value name="department_id" type="Int" nullable="true"/>
+   <value name="department_name" type="Text" nullable="true"/>
+  </schema>
+ </table>
+ <table name="test28">
+  <schema>
+   <value name="employee_id" type="Int" nullable="true"/>
+   <value name="department_id" type="Int" nullable="true"/>
+   <value name="salary" type="Decimal" nullable="true"/>
+  </schema>
+ </table>
+</sqlgg>


### PR DESCRIPTION
### Description
This PR adds the missing ambiguous checks for `WHERE`, `ORDER BY`, `GROUP BY` and `HAVING` for some cases which were not previously supported

One of these cases (that are reflected in tests) is:

#### DDL:
```sql
CREATE TABLE test21 (id INT, column_a TEXT, column_b BOOL);
CREATE TABLE test22 (id INT, column_d INT);
```

#### Queries

##### First
```sql
SELECT test21.id 
FROM test21 JOIN test22 ON test21.id = test22.id 
WHERE id > 2 ORDER BY id
```

##### Second
```sql
SELECT test21.id 
FROM test21 JOIN test22 ON test21.id = test22.id 
ORDER BY id
```

The first one fails unlike the second one, because `ORDER BY`, `HAVING`, `GROUP BY`  allow have column without explicit referring to source if it's specified in SELECT when ambiguous fields are present.

### Ambiguous Column Rule:

I have empirically tested all cases across three databases: MySQL, PostgreSQL and SQLite. Here are the main tests that are designed to be false positives (i.e., cases that should fail) along with their corresponding Playground links:

[Testing on PostgreSQL](https://www.db-fiddle.com/f/o7ENo2ga8mR3YJfsiyrwzv/6)
[Testing on MySQL](https://www.db-fiddle.com/f/o7ENo2ga8mR3YJfsiyrwzv/7)
[Testing on SQLite](https://www.db-fiddle.com/f/o7ENo2ga8mR3YJfsiyrwzv/5)

### Comparison of versions

##### DDL

```sql
CREATE TABLE test21 (id INT, column_a TEXT, column_b BOOL);
CREATE TABLE test22 (id INT, column_d INT);
CREATE TABLE test2 (id INT, str TEXT);
CREATE TABLE test (id INT, str TEXT, name TEXT);
```

Ambiguous error - 🔴
No errors - 🟢
Warnings - 🟡
Syntax error - ❓

<table>
  <tr>
    <th>Query</th>
    <th>Before this PR <a href="https://github.com/ahrefs/sqlgg/tree/acee7df6cd4c9821ed420fe6e1f7e11fd3847bf9">Branch</a></th>
    <th>Since this PR</th>
    <th>Mysq</th>
    <th>Pgsql</th>
    <th>Sqlite</th>
    <th>Ambiguous reason/expression</th>
    <th>Playground</th>
  </tr>
  <tr>
    <td><pre lang="sql">SELECT test21.id 
FROM test21 
JOIN test22 ON test21.id = test22.id 
WHERE id > 2;</pre></td>
    <td>🟢</td>
    <td>🔴</td>
    <td>🔴</td>
    <td>🔴</td>
    <td>🔴</td>
    <td><code>WHERE</code> expression</td>
    <td><a href="https://www.db-fiddle.com/f/m2hKgSpHr2J2PKmxHeDEg7/1">Link</a></td>
  </tr>
  <tr>
  <tr>
    <td><pre lang="sql">UPDATE test, (SELECT * FROM test2) AS x
SET str = x.str
WHERE test.id = x.id;
</pre></td>
    <td>🟢</td>
    <td>🔴</td>
    <td>🔴</td>
    <td>❓</td>
    <td>❓</td>
    <td><code>SET</code> expression</td>
    <td><a href="https://www.db-fiddle.com/f/rXgv5UT2vLnBNhMWDTvaDH/0">Link</a></td>
  </tr>
<tr>
  <tr>
    <td><pre lang="sql">SELECT *
FROM test21
JOIN test22 on test21.id = test22.id
GROUP BY id;
</pre></td>
    <td>🟢</td>
    <td>🟡 It throws </br> warning .
   But this</br> warning isn't </br> related with <code>GROUP BY</code> !
  </td>
    <td>🔴</td>
    <td>🔴</td>
    <td>🔴</td>
    <td><code>GROUP</code> expression</td>
    <td><a href="https://www.db-fiddle.com/f/7f1gkmZ1Uois1NFhxusP82/0">Link</a></td>
  </tr>
<tr>
  <tr>
    <td><pre lang="sql">SELECT *
FROM test21
JOIN test22 on test21.id = test22.id
ORDER BY id;
</pre></td>
    <td>🟢</td>
    <td>🟡 It throws </br> warning .
   But this</br> warning isn't </br> related with <code>ORDER BY</code> !
  </td>
    <td>🔴</td>
    <td>🔴</td>
    <td>🔴</td>
    <td><code>ORDER</code> expression</td>
    <td><a href="https://www.db-fiddle.com/f/znX9rcqN8exsRkgqcvpLW/0">Link</a></td>
  </tr>
<tr>
  <tr>
    <td><pre lang="sql">SELECT MAX(id) as id2
FROM test21
WHERE id2 > 0;
</pre></td>
    <td>🟢</td>
    <td>🔴</td>
    <td>🔴</td>
    <td>🔴</td>
    <td>🔴</td>
    <td><code>ORDER</code> expression</td>
    <td><a href="https://www.db-fiddle.com/f/ct6Q22GiUcUo4hvkhAbxT9/0">Link</a></td>
  </tr>
</table>